### PR TITLE
[#28] 마이페이지 마크업

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "framer-motion": "^9.0.2",
     "next": "13.1.6",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.43.2"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",

--- a/public/icons/close.svg
+++ b/public/icons/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>close</title><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Flex } from '@chakra-ui/react';
+import UserForm from '@/ui/UserForm';
+
+const EditMyPage = () => {
+  return (
+    <Flex
+      direction="column"
+      justify="center"
+      align="center"
+      gap="2rem"
+      py="4rem"
+    >
+      <UserForm />
+    </Flex>
+  );
+};
+
+export default EditMyPage;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flex, Box, useTheme, Text } from '@chakra-ui/react';
-import UserAvatar from '@/ui/UserAvatar';
+import LinkAvatar from '@/ui/LinkAvatar';
 import Link from 'next/link';
 
 const User = {
@@ -19,7 +19,7 @@ const MyPage = () => {
   return (
     <Flex direction="column" justify="center" gap="2rem" py="4rem" px="2rem">
       <Flex width="100%" gap="1.5rem">
-        <UserAvatar
+        <LinkAvatar
           src={profileImage}
           name={nickName}
           // TODO: API 받으면 사용자의 프로필 페이지로 이동하도록 구현

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -28,17 +28,17 @@ const MyPage = () => {
           h="6rem"
         />
         <Flex direction="column" justify="center">
-          <Box fontSize={theme.size.lg}>{nickName}</Box>
-          <Box fontSize={theme.size.sm}>{email}</Box>
+          <Box>{nickName}</Box>
+          <Box>{email}</Box>
         </Flex>
       </Flex>
       <Box>
-        <Box fontSize={theme.size.sm}>직군 / 직업</Box>
-        <Box fontSize={theme.size.md}>{job}</Box>
+        <Box>직군 / 직업</Box>
+        <Box>{job}</Box>
       </Box>
       <Box>
-        <Box fontSize={theme.size.sm}>내 책장</Box>
-        <Box fontSize={theme.size.md}>책장이 비어있습니다.</Box>
+        <Box>내 책장</Box>
+        <Box>책장이 비어있습니다.</Box>
       </Box>
       <Box
         as={Link}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Flex, Box, useTheme } from '@chakra-ui/react';
+import UserAvatar from '@/ui/UserAvatar';
+import Link from 'next/link';
+
+const User = {
+  nickName: '다독이',
+  profileImage: 'https://avatars.githubusercontent.com/u/48359052?v=4',
+  email: 'minjongbaek@gmail.com',
+  job: 'IT/프론트엔드 개발자',
+};
+
+const MyPage = () => {
+  const { nickName, profileImage, email, job } = User;
+
+  const theme = useTheme();
+
+  return (
+    <Flex direction="column" justify="center" gap="1rem" py="4rem" px="2rem">
+      <Flex width="100%" gap="1rem">
+        <UserAvatar
+          src={profileImage}
+          name={nickName}
+          // TODO: API 받으면 사용자의 프로필 페이지로 이동하도록 구현
+          href="/mypage"
+          w="6rem"
+          h="6rem"
+        />
+        <Flex direction="column" justify="center">
+          <Box fontSize={theme.size.lg}>{nickName}</Box>
+          <Box fontSize={theme.size.sm}>{email}</Box>
+        </Flex>
+      </Flex>
+      <Box>
+        <Box fontSize={theme.size.sm}>직군 / 직업</Box>
+        <Box fontSize={theme.size.md}>{job}</Box>
+      </Box>
+      <Box>
+        <Box fontSize={theme.size.sm}>내 책장</Box>
+        <Box fontSize={theme.size.md}>책장이 비어있습니다.</Box>
+      </Box>
+      <Box
+        as={Link}
+        href="mypage/edit"
+        px="2rem"
+        py="1rem"
+        color={theme.colors.main}
+        border="1px solid"
+        borderRadius="5rem"
+        textAlign="center"
+      >
+        프로필 수정
+      </Box>
+    </Flex>
+  );
+};
+
+export default MyPage;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flex, Box, useTheme } from '@chakra-ui/react';
+import { Flex, Box, useTheme, Text } from '@chakra-ui/react';
 import UserAvatar from '@/ui/UserAvatar';
 import Link from 'next/link';
 
@@ -17,28 +17,28 @@ const MyPage = () => {
   const theme = useTheme();
 
   return (
-    <Flex direction="column" justify="center" gap="1rem" py="4rem" px="2rem">
-      <Flex width="100%" gap="1rem">
+    <Flex direction="column" justify="center" gap="2rem" py="4rem" px="2rem">
+      <Flex width="100%" gap="1.5rem">
         <UserAvatar
           src={profileImage}
           name={nickName}
           // TODO: API 받으면 사용자의 프로필 페이지로 이동하도록 구현
           href="/mypage"
-          w="6rem"
-          h="6rem"
+          w="8rem"
+          h="8rem"
         />
         <Flex direction="column" justify="center">
-          <Box>{nickName}</Box>
-          <Box>{email}</Box>
+          <Text fontSize="xl">{nickName}</Text>
+          <Text fontSize="sm">{email}</Text>
         </Flex>
       </Flex>
       <Box>
-        <Box>직군 / 직업</Box>
-        <Box>{job}</Box>
+        <Text fontSize="sm">직군 / 직업</Text>
+        <Text fontSize="md">{job}</Text>
       </Box>
       <Box>
-        <Box>내 책장</Box>
-        <Box>책장이 비어있습니다.</Box>
+        <Text fontSize="sm">내 책장</Text>
+        <Text fontSize="md">책장이 비어있습니다.</Text>
       </Box>
       <Box
         as={Link}
@@ -49,6 +49,7 @@ const MyPage = () => {
         border="1px solid"
         borderRadius="5rem"
         textAlign="center"
+        fontSize="md"
       >
         프로필 수정
       </Box>

--- a/src/constants/FormRule/index.ts
+++ b/src/constants/FormRule/index.ts
@@ -1,0 +1,24 @@
+export const nickNameRule = {
+  required: '닉네임을 입력해주세요.',
+  minLength: {
+    value: 2,
+    message: '닉네임을 2자 이상 입력해주세요.',
+  },
+  maxLength: {
+    value: 10,
+    message: '닉네임을 10자 이하로 입력해주세요.',
+  },
+};
+
+export const emailRule = {
+  required: '이메일을 입력해주세요',
+  pattern: {
+    value:
+      /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/,
+    message: '이메일 형식을 다시 확인해주세요.',
+  },
+};
+
+export const jobRule = {
+  required: '직군을 입력해주세요.',
+};

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -2,7 +2,7 @@
 
 import { extendTheme, ThemeOverride } from '@chakra-ui/react';
 
-const size = {
+const fontSizes = {
   sm: '1.4rem',
   md: '1.6rem',
   lg: '1.8rem',
@@ -34,7 +34,7 @@ const colors = {
 };
 
 const theme: ThemeOverride = extendTheme({
-  size,
+  fontSizes,
   colors,
   styles: {
     global: {

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -2,6 +2,13 @@
 
 import { extendTheme, ThemeOverride } from '@chakra-ui/react';
 
+const size = {
+  sm: '1.4rem',
+  md: '1.6rem',
+  lg: '1.8rem',
+  xl: '2rem',
+};
+
 const colors = {
   main: '#F6AD55', // Main Theme
   red: {
@@ -27,6 +34,7 @@ const colors = {
 };
 
 const theme: ThemeOverride = extendTheme({
+  size,
   colors,
   styles: {
     global: {

--- a/src/ui/LinkAvatar/index.tsx
+++ b/src/ui/LinkAvatar/index.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Box } from '@chakra-ui/react';
 import Link from 'next/link';
 
-interface UserAvatarProps {
+interface LinkAvatarPropsn {
   src: string;
   name: string;
   href: string;
@@ -9,13 +9,13 @@ interface UserAvatarProps {
   h?: string;
 }
 
-const UserAvatar = ({
+const LinkAvatar = ({
   src,
   name,
   href,
   w = '3.2rem',
   h = '3.2rem',
-}: UserAvatarProps) => {
+}: LinkAvatarPropsn) => {
   return (
     <Box w={w} h={h}>
       <Link href={href}>
@@ -25,4 +25,4 @@ const UserAvatar = ({
   );
 };
 
-export default UserAvatar;
+export default LinkAvatar;

--- a/src/ui/UserAvatar/index.tsx
+++ b/src/ui/UserAvatar/index.tsx
@@ -1,0 +1,28 @@
+import { Avatar, Box } from '@chakra-ui/react';
+import Link from 'next/link';
+
+interface UserAvatarProps {
+  src: string;
+  name: string;
+  href: string;
+  w?: string;
+  h?: string;
+}
+
+const UserAvatar = ({
+  src,
+  name,
+  href,
+  w = '3.2rem',
+  h = '3.2rem',
+}: UserAvatarProps) => {
+  return (
+    <Box w={w} h={h}>
+      <Link href={href}>
+        <Avatar name={name} src={src} w="100%" h="100%" />
+      </Link>
+    </Box>
+  );
+};
+
+export default UserAvatar;

--- a/src/ui/UserForm/UserInput/index.tsx
+++ b/src/ui/UserForm/UserInput/index.tsx
@@ -20,13 +20,7 @@ interface UserInputProps {
   resetField?: () => void;
 }
 
-const UserInput = ({
-  label,
-  id,
-  register,
-  error,
-  resetField,
-}: UserInputProps) => {
+const UserInput = ({ label, register, error, resetField }: UserInputProps) => {
   const theme = useTheme();
   const { colors } = theme;
 
@@ -51,11 +45,11 @@ const UserInput = ({
       onBlur={onInputBlur}
       isRequired={register ? register.required : false}
     >
-      <FormLabel htmlFor={id}>{label}</FormLabel>
-      <InputGroup size="lg">
-        <Input focusBorderColor={colors.main} {...register} />
+      <FormLabel>{label}</FormLabel>
+      <InputGroup>
+        <Input focusBorderColor={colors.main} py="2rem" {...register} />
         {resetField && isFocus && (
-          <InputRightElement>
+          <InputRightElement h="100%">
             <button type="button" onClick={onResetButtonClick}>
               <CloseIcon width="1.5rem" fill={colors.black['800']} />
             </button>

--- a/src/ui/UserForm/UserInput/index.tsx
+++ b/src/ui/UserForm/UserInput/index.tsx
@@ -62,7 +62,7 @@ const UserInput = ({
           </InputRightElement>
         )}
       </InputGroup>
-      <FormErrorMessage>{error?.message}</FormErrorMessage>
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </FormControl>
   );
 };

--- a/src/ui/UserForm/UserInput/index.tsx
+++ b/src/ui/UserForm/UserInput/index.tsx
@@ -1,0 +1,70 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  InputGroup,
+  InputRightElement,
+  useTheme,
+} from '@chakra-ui/react';
+import CloseIcon from '@public/icons/close.svg';
+import { useState } from 'react';
+import type { UseFormRegisterReturn, FieldError } from 'react-hook-form';
+
+interface UserInputProps {
+  isRequired?: boolean;
+  label: string;
+  id: string;
+  register?: UseFormRegisterReturn;
+  error?: FieldError;
+  resetField?: () => void;
+}
+
+const UserInput = ({
+  label,
+  id,
+  register,
+  error,
+  resetField,
+}: UserInputProps) => {
+  const theme = useTheme();
+  const { colors } = theme;
+
+  const onResetButtonClick = () => {
+    resetField && resetField();
+  };
+
+  const [isFocus, setIsFocus] = useState(false);
+
+  const onInputFocus = () => {
+    setIsFocus(true);
+  };
+
+  const onInputBlur = () => {
+    setIsFocus(false);
+  };
+
+  return (
+    <FormControl
+      isInvalid={!!error}
+      onFocus={onInputFocus}
+      onBlur={onInputBlur}
+      isRequired={register ? register.required : false}
+    >
+      <FormLabel htmlFor={id}>{label}</FormLabel>
+      <InputGroup size="lg">
+        <Input focusBorderColor={colors.main} {...register} />
+        {resetField && isFocus && (
+          <InputRightElement>
+            <button type="button" onClick={onResetButtonClick}>
+              <CloseIcon width="1.5rem" fill={colors.black['800']} />
+            </button>
+          </InputRightElement>
+        )}
+      </InputGroup>
+      <FormErrorMessage>{error?.message}</FormErrorMessage>
+    </FormControl>
+  );
+};
+
+export default UserInput;

--- a/src/ui/UserForm/index.tsx
+++ b/src/ui/UserForm/index.tsx
@@ -8,7 +8,7 @@ const UserForm = () => {
     register,
     handleSubmit,
     resetField,
-    formState: { errors, isSubmitting, isValid },
+    formState: { errors, isSubmitting },
   } = useForm({
     mode: 'all',
     defaultValues: {
@@ -81,7 +81,7 @@ const UserForm = () => {
         mt="2rem"
         px="2rem"
         py="1rem"
-        disabled={isSubmitting || !isValid}
+        disabled={isSubmitting}
         color={theme.colors.main}
         border="1px solid"
         borderRadius="5rem"

--- a/src/ui/UserForm/index.tsx
+++ b/src/ui/UserForm/index.tsx
@@ -1,0 +1,99 @@
+import { Avatar, Box, Flex, useTheme } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import UserInput from './UserInput/index';
+import { emailRule, jobRule, nickNameRule } from '@/constants/FormRule';
+
+const UserForm = () => {
+  const {
+    register,
+    handleSubmit,
+    resetField,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm({
+    mode: 'all',
+    defaultValues: {
+      nickname: '',
+      email: '',
+      job: '',
+    },
+  });
+
+  const onUserFormSubmit: Parameters<typeof handleSubmit>[0] = async ({
+    nickname,
+    email,
+    job,
+  }) => {
+    /**
+     * 딜레이 테스트 함수
+     * @returns
+     */
+    const delay = () => {
+      return new Promise<void>(resolve =>
+        setTimeout(() => {
+          console.log('submit');
+          resolve();
+        }, 1000)
+      );
+    };
+
+    await delay();
+
+    // TODO: 프로필 수정 API 연동
+    console.log(nickname);
+    console.log(email);
+    console.log(job);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <Box as="form" w="100%" px="2rem" onSubmit={handleSubmit(onUserFormSubmit)}>
+      <Flex direction="column" gap="1rem" align="center">
+        {/* TODO: API 받으면 프로필 이미지 구현 */}
+        <Avatar w="6rem" h="6rem" />
+        <UserInput
+          label="닉네임"
+          id="nickname"
+          register={register('nickname', nickNameRule)}
+          error={errors.nickname}
+          resetField={() => resetField('nickname')}
+        />
+        <UserInput
+          label="이메일"
+          id="email"
+          register={register('email', emailRule)}
+          error={errors.email}
+          resetField={() => resetField('email')}
+        />
+        {/* #TODO: API 받으면 셀렉트 박스로 구현 */}
+        <UserInput
+          label="직군 / 직업"
+          id="job"
+          register={register('job', jobRule)}
+          error={errors.job}
+          resetField={() => resetField('job')}
+        />
+        {/* #TODO: 책장 컴포넌트 구현되면 연결 */}
+      </Flex>
+      <Box
+        as="button"
+        w="100%"
+        mt="2rem"
+        px="2rem"
+        py="1rem"
+        disabled={isSubmitting || !isValid}
+        color={theme.colors.main}
+        border="1px solid"
+        borderRadius="5rem"
+        _disabled={{
+          color: `${theme.colors.black['500']}`,
+          border: '1px solid',
+        }}
+      >
+        프로필 수정
+      </Box>
+    </Box>
+  );
+};
+
+export default UserForm;

--- a/src/ui/UserForm/index.tsx
+++ b/src/ui/UserForm/index.tsx
@@ -50,7 +50,7 @@ const UserForm = () => {
     <Box as="form" w="100%" px="2rem" onSubmit={handleSubmit(onUserFormSubmit)}>
       <Flex direction="column" gap="1rem" align="center">
         {/* TODO: API 받으면 프로필 이미지 구현 */}
-        <Avatar w="6rem" h="6rem" />
+        <Avatar w="8rem" h="8rem" />
         <UserInput
           label="닉네임"
           id="nickname"
@@ -85,6 +85,7 @@ const UserForm = () => {
         color={theme.colors.main}
         border="1px solid"
         borderRadius="5rem"
+        fontSize="md"
         _disabled={{
           color: `${theme.colors.black['500']}`,
           border: '1px solid',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@public/*": ["public/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4597,6 +4597,11 @@ react-focus-lock@^2.9.2:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-hook-form@^7.43.2:
+  version "7.43.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.2.tgz#d8ff71956dc3de258dce19d4b1c7e1c6a0188e67"
+  integrity sha512-NvD3Oe2Y9hhqo2R4I4iJigDzSLpdMnzUpNMxlnzTbdiT7NT3BW0GxWCzEtwPudZMUPbZhNcSy1EcGAygyhDORg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

* 마이페이지를 마크업 했습니다.
* 프로필 페이지와 수정 페이지에서 다른 UI를 제공하는 것이 더 좋을 것 같아서 두 페이지의 디자인 다르게 적용했습니다.

# 스크린샷

<img src="https://user-images.githubusercontent.com/48359052/221352973-01f8ae97-270d-44cb-b9de-47a12703bafc.png" width="360" />

<img src="https://user-images.githubusercontent.com/48359052/221352824-a6a62df0-9c38-469f-b149-26d4b0b23538.png" width="360" />

# PR 포인트

* 어제 회의 내용을 반영하여 폰트 사이즈를 theme 에 설정해두었습니다.

# Help

* 피그마에 있는 상단 버튼과 폼 이벤트를 연결하는데 생각보다 복잡해서 우선 폼 안에 버튼을 구현하였습니다.
  * 데모데이 이후에 적용하도록 하겠습니다.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/48359052/221351649-be5e0aa1-b552-40bd-8464-8cbe2a9564be.png">

# 관련 이슈

- Close #28 
