### PR TITLE
[#59] 책 검색 페이지 & 책 상세 페이지 마크업

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Goback from '@/ui/GoBack';
+import { Avatar, AvatarGroup, Box, Flex, Text, VStack } from '@chakra-ui/react';
+import Image from 'next/image';
+
+const BookDetailPage = () => {
+  return (
+    <Box w="100%">
+      <Goback />
+      <VStack
+        bgColor="white"
+        ml="2rem"
+        p="2rem"
+        shadow="lg"
+        align="stretch"
+        borderLeftRadius={15}
+        gap="2rem"
+      >
+        <Flex gap="2rem" align="flex-end">
+          <Box shadow="lg">
+            <Image
+              src="/images/img_functionalBook.png"
+              alt="book"
+              width={180}
+              height={240}
+            />
+          </Box>
+          <VStack align="flex-start">
+            <Text fontSize="lg" fontWeight="bold">
+              챗 GPT(마침내 찾아온 특이점)
+            </Text>
+            <Text fontSize="sm">백민종</Text>
+            <Text fontSize="sm" fontWeight="bold" color="main">
+              3.5 / 5
+            </Text>
+          </VStack>
+        </Flex>
+        <Text fontSize="md">
+          챗 GPT 어쩌구 저쩌구 이러쿵 저러쿵 이래라 저래라 엘엘레 얼래벌래, 챗
+          GPT 어쩌구 저쩌구 이러쿵 저러쿵 이래라 저래라 엘엘레 얼래벌래, 챗 GPT
+          어쩌구 저쩌구 이러쿵 저러쿵 이래라 저래라 엘엘레 얼래벌래, 챗 GPT
+          어쩌구 저쩌구 이러쿵 저러쿵 이래라 저래라 엘엘레 얼래벌래
+        </Text>
+        <Flex align="center" gap="0.8rem">
+          <AvatarGroup max={2}>
+            <Avatar></Avatar>
+            <Avatar></Avatar>
+            <Avatar></Avatar>
+            <Avatar></Avatar>
+            <Avatar></Avatar>
+          </AvatarGroup>
+          <Text fontSize="sm">외 3명이 이 책을 책장에 꽂았습니다.</Text>
+        </Flex>
+      </VStack>
+    </Box>
+  );
+};
+
+export default BookDetailPage;

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import SearchingBook from '@/ui/CreateMeeting/SelectingBook/SearchingBook';
+import { Box } from '@chakra-ui/react';
+
+const BookPage = () => {
+  return (
+    <Box w="100%">
+      <SearchingBook />
+    </Box>
+  );
+};
+
+export default BookPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import ChakraThemeProvider from '@/components/ChakraThemeProvider';
 import ReactQueryProvier from '@/components/ReactQueryProvider';
 import BottomNavigation from '@/ui/BottomNavigation';
 import { LineSeed } from '@/styles/font';
+import { Box } from '@chakra-ui/react';
 
 export default function RootLayout({
   children,
@@ -14,7 +17,7 @@ export default function RootLayout({
       <body className={LineSeed.className}>
         <ReactQueryProvier>
           <ChakraThemeProvider>
-            {children}
+            <Box mb="9rem">{children}</Box>
             <BottomNavigation />
           </ChakraThemeProvider>
         </ReactQueryProvier>

--- a/src/ui/BottomNavigation/index.tsx
+++ b/src/ui/BottomNavigation/index.tsx
@@ -40,6 +40,7 @@ const BottomNavigation = () => {
       bottom={0}
       w="100%"
       maxW="43rem"
+      maxH="9rem"
     >
       {navigationItems.map(({ iconName, label, href }) => (
         <NavigationItem

--- a/src/ui/CreateMeeting/SelectingBook/SearchingBook/index.tsx
+++ b/src/ui/CreateMeeting/SelectingBook/SearchingBook/index.tsx
@@ -3,13 +3,13 @@
 import SearchedBook from './SearchedBook';
 import { useState } from 'react';
 import {
-  Box,
   Input,
   Flex,
   Image,
   Button,
   VStack,
   SimpleGrid,
+  Text,
 } from '@chakra-ui/react';
 
 const SearchingBook = () => {
@@ -79,13 +79,13 @@ const SearchingBook = () => {
 
   return (
     /* bottom Sheet 높이는 maxWidth 지정 후 변경 예정 */
-    <VStack px="2rem" h="50rem">
-      <Flex h="10rem" fontSize="lg" align="center" mt="2rem">
-        <Box as="span" color="main">
+    <VStack px="2rem">
+      <Text fontSize="lg" align="center" mt="2rem">
+        <Text as="span" color="main">
           책
-        </Box>
+        </Text>
         을 선택해 주세요
-      </Flex>
+      </Text>
       <Flex justify="center" as="form" onSubmit={handleSubmit}>
         <Flex mb="3rem">
           <Input
@@ -112,7 +112,7 @@ const SearchingBook = () => {
           </Button>
         </Flex>
       </Flex>
-      <SimpleGrid columns={[2, null, 3]} spacing="2rem" overflowY="scroll">
+      <SimpleGrid columns={2} spacing="2rem">
         {DummyData.map(book => (
           <SearchedBook
             key={book.id}


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

* 책 검색 페이지 마크업 
* 책 상세 페이지 마크업 

시간이 촉박하여 하나의 PR로 올린 점 양해 부탁드립니다.

# 스크린샷

<img src="https://user-images.githubusercontent.com/48359052/222110865-dcbf38ea-ac6c-4e5b-8036-5cc06db6d0bd.png" width=300 />


<img src="https://user-images.githubusercontent.com/48359052/222110728-f203ad31-edf5-4b52-86b3-c43047357211.png" width=300 />

# pr 포인트

@WooDaeHyun 책 검색 페이지에 SearchBook 컴포넌트를 사용했습니다. 해당 컴포넌트에 사이즈가 고정값으로 작성되어 있어서 제거했습니다. 여러 곳에서 사용하는 컴포넌트라면 사이즈와 관련된 Prop을 받거나, wrapper 요소의 크기를 따라가게끔 하는 것이 좋을 것 같습니다.

# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #59 
