### PR TITLE
[#80] mixedContent 이슈 해결을 위한 URL 프록시 적용

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const baseURL = process.env.NEXT_PUBLIC_API_URL;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -17,6 +19,14 @@ const nextConfig = {
         source: '/',
         destination: '/bookarchive/',
         permanent: false,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:url*',
+        destination: `${baseURL}/api/:url*`,
       },
     ];
   },

--- a/src/apis/core/axios.ts
+++ b/src/apis/core/axios.ts
@@ -43,7 +43,6 @@ const options: CreateAxiosDefaults = {
 
 export const publicApi = setInterceptor(
   axios.create({
-    baseURL: process.env.NEXT_PUBLIC_API_URL,
     ...options,
   })
 );


### PR DESCRIPTION
# 구현 내용

* 백엔드 서버에 SSL 인증서가 적용되지 않아 클라이언트에서 Proxy 설정을 했습니다.
  * next.js 에서 제공하는 rewrites 기능을 이용해 Proxy 설정을 했습니다.
  * /api~ 로 가는 모든 요청들은 NEXT_PUBLIC_API_URL/api~ 로 넘어갑니다.

# 관련 이슈

- Close #80 
