### PR TITLE
[#74] 모임 리스트 페이지 검색창 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,14 +22,14 @@ const nextConfig = {
       },
     ];
   },
-  // async rewrites() {
-  //   return [
-  //     {
-  //       source: '/api/:url*',
-  //       destination: `${baseURL}/api/:url*`,
-  //     },
-  //   ];
-  // },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:url*',
+        destination: `${baseURL}/api/:url*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -22,14 +22,14 @@ const nextConfig = {
       },
     ];
   },
-  async rewrites() {
-    return [
-      {
-        source: '/api/:url*',
-        destination: `${baseURL}/api/:url*`,
-      },
-    ];
-  },
+  // async rewrites() {
+  //   return [
+  //     {
+  //       source: '/api/:url*',
+  //       destination: `${baseURL}/api/:url*`,
+  //     },
+  //   ];
+  // },
 };
 
 module.exports = nextConfig;

--- a/src/ui/Meeting/MeetingSearch/index.tsx
+++ b/src/ui/Meeting/MeetingSearch/index.tsx
@@ -1,14 +1,43 @@
+import { useState } from 'react';
 import { Input, Select, Button, Image, Flex } from '@chakra-ui/react';
 
-const MeetingSearch = () => {
+interface setSearchValueProps {
+  input: string;
+  select: string;
+}
+interface MeetingSearchProps {
+  setSearchValue: (arg0: setSearchValueProps) => void;
+}
+
+const MeetingSearch = ({ setSearchValue }: MeetingSearchProps) => {
+  const [inputValue, setInputValue] = useState('');
+  const [selectValue, setSelectValue] = useState('모임');
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectValue(event.target.value);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLDivElement>) => {
+    event && event.preventDefault();
+    setSearchValue({
+      input: inputValue,
+      select: selectValue,
+    });
+  };
+
   return (
-    <Flex as="form" m="1rem 0" boxShadow="default">
+    <Flex as="form" m="1rem 0" boxShadow="default" onSubmit={handleSubmit}>
       <Select
         w="14rem"
         h="3.5rem"
         borderRightRadius="none"
         borderRight="none"
         variant="filled"
+        onChange={handleSelectChange}
       >
         <option value="모임">모임</option>
         <option value="책 제목">책 제목</option>
@@ -19,6 +48,7 @@ const MeetingSearch = () => {
         background="white"
         border="none"
         placeholder="검색어를 입력해 주세요."
+        onChange={handleInputChange}
       />
       <Button
         type="submit"

--- a/src/ui/Meeting/MeetingSearch/index.tsx
+++ b/src/ui/Meeting/MeetingSearch/index.tsx
@@ -1,0 +1,36 @@
+import { Input, Select, Button, Image, Flex } from '@chakra-ui/react';
+
+const MeetingSearch = () => {
+  return (
+    <Flex as="form" m="1rem 0" boxShadow="default">
+      <Select
+        w="14rem"
+        h="3.5rem"
+        borderRightRadius="none"
+        borderRight="none"
+        variant="filled"
+      >
+        <option value="모임">모임</option>
+        <option value="책 제목">책 제목</option>
+      </Select>
+      <Input
+        borderRadius="none"
+        h="3.5rem"
+        background="white"
+        border="none"
+        placeholder="검색어를 입력해 주세요."
+      />
+      <Button
+        type="submit"
+        h="3.5rem"
+        background="white"
+        border="none"
+        borderLeftRadius="none"
+      >
+        <Image src="/icons/search.svg" alt="검색버튼" />
+      </Button>
+    </Flex>
+  );
+};
+
+export default MeetingSearch;

--- a/src/ui/Meeting/MeetingSearch/index.tsx
+++ b/src/ui/Meeting/MeetingSearch/index.tsx
@@ -8,12 +8,12 @@ import {
   InputGroup,
 } from '@chakra-ui/react';
 
-interface setSearchValueProps {
+interface SearchValue {
   input: string;
   select: string;
 }
 interface MeetingSearchProps {
-  searchValue: setSearchValueProps;
+  searchValue: SearchValue;
   handleChange: (name: string, value: string) => void;
   handleSumbit: () => void;
 }

--- a/src/ui/Meeting/MeetingSearch/index.tsx
+++ b/src/ui/Meeting/MeetingSearch/index.tsx
@@ -1,64 +1,80 @@
-import { useState } from 'react';
-import { Input, Select, Button, Image, Flex } from '@chakra-ui/react';
+import { SearchIcon } from '@chakra-ui/icons';
+import {
+  Input,
+  Select,
+  Flex,
+  InputRightElement,
+  IconButton,
+  InputGroup,
+} from '@chakra-ui/react';
 
 interface setSearchValueProps {
   input: string;
   select: string;
 }
 interface MeetingSearchProps {
-  setSearchValue: (arg0: setSearchValueProps) => void;
+  searchValue: setSearchValueProps;
+  handleChange: (name: string, value: string) => void;
+  handleSumbit: () => void;
 }
 
-const MeetingSearch = ({ setSearchValue }: MeetingSearchProps) => {
-  const [inputValue, setInputValue] = useState('');
-  const [selectValue, setSelectValue] = useState('모임');
-
-  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectValue(event.target.value);
-  };
-
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value);
-  };
+const MeetingSearch = ({
+  searchValue,
+  handleChange,
+  handleSumbit,
+}: MeetingSearchProps) => {
+  const { input, select } = searchValue;
 
   const handleSubmit = (event: React.FormEvent<HTMLDivElement>) => {
     event && event.preventDefault();
-    setSearchValue({
-      input: inputValue,
-      select: selectValue,
-    });
+    handleSumbit();
   };
 
   return (
-    <Flex as="form" m="1rem 0" boxShadow="default" onSubmit={handleSubmit}>
+    <Flex
+      as="form"
+      m="1rem 0"
+      onSubmit={handleSubmit}
+      borderRadius="1rem"
+      boxShadow="default"
+    >
       <Select
         w="14rem"
         h="3.5rem"
         borderRightRadius="none"
+        borderLeftRadius="1rem"
         borderRight="none"
         variant="filled"
-        onChange={handleSelectChange}
+        onChange={event => handleChange('select', event.target.value)}
+        value={select}
       >
         <option value="모임">모임</option>
         <option value="책 제목">책 제목</option>
       </Select>
-      <Input
-        borderRadius="none"
-        h="3.5rem"
-        background="white"
-        border="none"
-        placeholder="검색어를 입력해 주세요."
-        onChange={handleInputChange}
-      />
-      <Button
-        type="submit"
-        h="3.5rem"
-        background="white"
-        border="none"
-        borderLeftRadius="none"
-      >
-        <Image src="/icons/search.svg" alt="검색버튼" />
-      </Button>
+      <InputGroup>
+        <Input
+          borderRightRadius="1rem"
+          borderLeftRadius="none"
+          h="3.5rem"
+          background="white"
+          border="none"
+          placeholder="검색어를 입력해 주세요."
+          onChange={event => handleChange('input', event.target.value)}
+          value={input}
+        />
+        <InputRightElement>
+          <IconButton
+            m="1rem 0.6rem 0 0"
+            bgColor="white"
+            borderRightRadius="1rem"
+            h="3.5rem"
+            aria-label="Search database"
+            icon={<SearchIcon />}
+            type="submit"
+            size="lg"
+          />
+        </InputRightElement>
+      </InputGroup>
     </Flex>
   );
 };

--- a/src/ui/Meeting/index.tsx
+++ b/src/ui/Meeting/index.tsx
@@ -1,62 +1,87 @@
 'use client';
 import { Flex } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 
 import MeetingListHeader from './MeetingListHeader';
 import MeetingSearch from './MeetingSearch';
 import MeetingList from './MeetingList';
 
+const DUMMY_DATA = [
+  {
+    title: '악인을 만난적인 있나요?',
+    content:
+      '늘 감사하고 착한 사람 콤플렉스에 빠져 우울한 현실을 마주한 저자가 분노와 열등감으로 자신이 주도하는 삶을 살게 된 이야기를 담았다. 말하기, 글쓰기 기술을 비롯, 훈련을 통해 개발한 성공의 5가지 무기로 치열하게 자신을 불태울 각오로 노력하는 삶으로 이끄는 책이다.',
+    id: 234,
+    avatar: 'https://image.yes24.com/Goods/117498667/L',
+    nickName: '아라한장풍',
+    people: 1,
+    comments: 1,
+    bookImageURL: 'https://image.yes24.com/Goods/117498667/L',
+  },
+  {
+    title: '주식 투자에 매번 실패하시는 분!',
+    content:
+      '성장할 것 같은 종목을 고르고, 해당 종목을 적절한 때 매수 매도해야 하며, 이 과정에서 잘못 들어갔다면 확실한 손절점을 정해서 손실을 보더라도 빠져나와야 결과적으로 수익을 볼 수 있다는 것이다. 초고수익은 운으로 만들어지지 않는다. 마크 미너비니가 공유한 투자법을 통해 모두 차세대 애플, 구글, 스타벅스를 찾길 바란다.',
+    id: 2525,
+    avatar: 'https://bit.ly/dan-abramov',
+    nickName: '잠실동쭈꾸미',
+    people: 22,
+    comments: 23,
+    bookImageURL: 'https://image.yes24.com/Goods/117650984/L',
+  },
+  {
+    title: '살 때, 팔 때, 벌 때',
+    content:
+      '“주식의 시간은 따로 있다!”여의도 1타 브로커 강영현이 공개하는 2023 혼돈의 시장을 돌파할 최강 투자 바이블!',
+    id: 7575,
+    avatar: 'http://image.yes24.com/goods/117614110/XL',
+    nickName: '응모아조씨',
+    people: 3233,
+    comments: 3233,
+    bookImageURL: 'http://image.yes24.com/goods/117614110/XL',
+  },
+  {
+    title: '톨스토이 책 읽으신 분들',
+    content:
+      '러시아의 세계적인 대문호이자 사상가인 톨스토이의 단편집. 인생의 진정한 의미를 잃어버린 사람들을 위해서 글을 쓴 톨스토이와 그의 작품들은 백 년이 지난 지금도 우리에게 강한 울림을 주고 있다.',
+    id: 90,
+    avatar: 'https://image.yes24.com/goods/117726598/L',
+    nickName: '도마뱀꼬리는재생',
+    people: 423,
+    comments: 423,
+    bookImageURL: 'https://image.yes24.com/goods/117726598/L',
+  },
+];
+
+interface props {
+  title: string;
+  content: string;
+  id: number;
+  avatar: string;
+  nickName: string;
+  people: number;
+  comments: number;
+  bookImageURL: string;
+}
+
 const MeetingPageContainer = () => {
-  const DUMMY_DATA = [
-    {
-      title: '악인을 만난적인 있나요?',
-      content:
-        '늘 감사하고 착한 사람 콤플렉스에 빠져 우울한 현실을 마주한 저자가 분노와 열등감으로 자신이 주도하는 삶을 살게 된 이야기를 담았다. 말하기, 글쓰기 기술을 비롯, 훈련을 통해 개발한 성공의 5가지 무기로 치열하게 자신을 불태울 각오로 노력하는 삶으로 이끄는 책이다.',
-      id: 234,
-      avatar: 'https://image.yes24.com/Goods/117498667/L',
-      nickName: '아라한장풍',
-      people: 1,
-      comments: 1,
-      bookImageURL: 'https://image.yes24.com/Goods/117498667/L',
-    },
-    {
-      title: '주식 투자에 매번 실패하시는 분!',
-      content:
-        '성장할 것 같은 종목을 고르고, 해당 종목을 적절한 때 매수 매도해야 하며, 이 과정에서 잘못 들어갔다면 확실한 손절점을 정해서 손실을 보더라도 빠져나와야 결과적으로 수익을 볼 수 있다는 것이다. 초고수익은 운으로 만들어지지 않는다. 마크 미너비니가 공유한 투자법을 통해 모두 차세대 애플, 구글, 스타벅스를 찾길 바란다.',
-      id: 2525,
-      avatar: 'https://bit.ly/dan-abramov',
-      nickName: '잠실동쭈꾸미',
-      people: 22,
-      comments: 23,
-      bookImageURL: 'https://image.yes24.com/Goods/117650984/L',
-    },
-    {
-      title: '살 때, 팔 때, 벌 때',
-      content:
-        '“주식의 시간은 따로 있다!”여의도 1타 브로커 강영현이 공개하는 2023 혼돈의 시장을 돌파할 최강 투자 바이블!',
-      id: 7575,
-      avatar: 'http://image.yes24.com/goods/117614110/XL',
-      nickName: '응모아조씨',
-      people: 3233,
-      comments: 3233,
-      bookImageURL: 'http://image.yes24.com/goods/117614110/XL',
-    },
-    {
-      title: '톨스토이 책 읽으신 분들',
-      content:
-        '러시아의 세계적인 대문호이자 사상가인 톨스토이의 단편집. 인생의 진정한 의미를 잃어버린 사람들을 위해서 글을 쓴 톨스토이와 그의 작품들은 백 년이 지난 지금도 우리에게 강한 울림을 주고 있다.',
-      id: 90,
-      avatar: 'https://image.yes24.com/goods/117726598/L',
-      nickName: '도마뱀꼬리는재생',
-      people: 423,
-      comments: 423,
-      bookImageURL: 'https://image.yes24.com/goods/117726598/L',
-    },
-  ];
+  const [MeetingListData, setMeetingListData] = useState<props[]>([]);
+  const [searchValue, setSearchValue] = useState({
+    input: '',
+    select: '',
+  });
+
+  useEffect(() => {
+    setMeetingListData(DUMMY_DATA);
+    /* 검색시 API 호출 예정*/
+    console.log(searchValue);
+  }, [searchValue]);
+
   return (
     <Flex mt="2rem" direction="column" px="5%" mb="9rem">
       <MeetingListHeader />
-      <MeetingSearch />
-      <MeetingList meetingInfo={DUMMY_DATA} />
+      <MeetingSearch setSearchValue={setSearchValue} />
+      <MeetingList meetingInfo={MeetingListData} />
     </Flex>
   );
 };

--- a/src/ui/Meeting/index.tsx
+++ b/src/ui/Meeting/index.tsx
@@ -64,23 +64,48 @@ interface props {
   bookImageURL: string;
 }
 
+interface SearchValue {
+  [key: string]: string;
+  input: string;
+  select: string;
+}
+
 const MeetingPageContainer = () => {
   const [MeetingListData, setMeetingListData] = useState<props[]>([]);
-  const [searchValue, setSearchValue] = useState({
+  const [searchValue, setSearchValue] = useState<SearchValue>({
     input: '',
-    select: '',
+    select: '모임',
   });
+
+  const handleSumbit = () => {
+    console.log(searchValue);
+    const { input } = searchValue;
+    if (input.trim().length === 0) {
+      /*공백만 입력한 경우 전체 데이터 렌더링 */
+    } else {
+      /*검색 API호출 및 setMeetingListData 업데이트 */
+    }
+  };
+
+  const handleChange = (name: string, value: string) => {
+    if (!(name in searchValue)) return;
+    const tempSearchValue = { ...searchValue };
+    tempSearchValue[name] = value;
+    setSearchValue(tempSearchValue);
+  };
 
   useEffect(() => {
     setMeetingListData(DUMMY_DATA);
-    /* 검색시 API 호출 예정*/
-    console.log(searchValue);
-  }, [searchValue]);
+  }, []);
 
   return (
     <Flex mt="2rem" direction="column" px="5%" mb="9rem">
       <MeetingListHeader />
-      <MeetingSearch setSearchValue={setSearchValue} />
+      <MeetingSearch
+        searchValue={searchValue}
+        handleChange={handleChange}
+        handleSumbit={handleSumbit}
+      />
       <MeetingList meetingInfo={MeetingListData} />
     </Flex>
   );

--- a/src/ui/Meeting/index.tsx
+++ b/src/ui/Meeting/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 import { Flex } from '@chakra-ui/react';
 
-import MeetingList from './MeetingList';
 import MeetingListHeader from './MeetingListHeader';
+import MeetingSearch from './MeetingSearch';
+import MeetingList from './MeetingList';
 
 const MeetingPageContainer = () => {
   const DUMMY_DATA = [
@@ -54,6 +55,7 @@ const MeetingPageContainer = () => {
   return (
     <Flex mt="2rem" direction="column" px="5%" mb="9rem">
       <MeetingListHeader />
+      <MeetingSearch />
       <MeetingList meetingInfo={DUMMY_DATA} />
     </Flex>
   );

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -66,7 +66,7 @@ const MeetingDetail = ({ meetingId }: MeetingDetailProps) => {
   }, [members, DUMMY_USER_ID, isJoinedMember]);
 
   return (
-    <Flex px="5%" direction="column" justify="center" mt="1rem" mb="9rem">
+    <Flex px="5%" direction="column" justify="center" mt="1rem">
       <MeetingInfo
         isJoinedMember={isJoinedMember}
         meetingInfoData={DUMMY_MEETING_DETAIL_INFO_DATA}


### PR DESCRIPTION
# 구현 내용

- 모임 리스트 페이지 검색창 구현

# 스크린샷
![스크린샷 2023-03-05 오전 6 37 34](https://user-images.githubusercontent.com/113018070/222929694-f0f95d47-2013-4d88-9e67-9a8fe41a3b8d.png)

# pr 포인트


# Help

MeetingSearch 컴포넌트에서 input과 select값을 각각 저장해서 submit이벤트 발생 시 객체에 담아서 
MeetingPageContainer컴포넌트로 올려서 검색 API 호출해서 리스트를 렌더링해주도록 로직을 구현했는데 어색하거나 이상한 부분이 있을까요? 가감없이 말씀해 주시면 많은 도움이 될 것 같습니다 ㅎㅎ!! 

# 관련 이슈

- Close #74 
