### PR TITLE
[#73] 프로필 추가정보 입력 페이지 API 연동

### DIFF
--- a/src/apis/job/index.ts
+++ b/src/apis/job/index.ts
@@ -1,0 +1,8 @@
+import { APIAllJob } from '@/types/job';
+import { publicApi } from '../core/axios';
+
+const jobAPI = {
+  getAllJobs: () => publicApi.get<APIAllJob>(`/api/jobs`),
+};
+
+export default jobAPI;

--- a/src/app/profile/me/add/page.tsx
+++ b/src/app/profile/me/add/page.tsx
@@ -18,7 +18,7 @@ const AdditionalProfile = () => {
       p="6rem 2rem"
       gap="1rem"
     >
-      <Heading fontSize="lg">추가 정보를 선택해주세요!</Heading>
+      <Heading fontSize="lg">추가 정보를 입력해주세요!</Heading>
       <Text fontSize="md" textAlign="center">
         추가 정보를 입력하면
         <br />

--- a/src/app/profile/me/add/page.tsx
+++ b/src/app/profile/me/add/page.tsx
@@ -1,27 +1,36 @@
 'use client';
 
+import useAllJobQuery from '@/queries/job/useAllJobQuery';
 import AdditionalProfileForm from '@/ui/AdditionalProfileForm';
 import { Heading, Text, VStack } from '@chakra-ui/react';
 
 const AdditionalProfile = () => {
+  const allJobQuery = useAllJobQuery();
+
+  if (!allJobQuery.isSuccess) return null;
+
   return (
     <VStack
       h="100vh"
       bgColor="white"
       position="relative"
       zIndex={10}
-      p="8rem 6rem"
+      p="6rem 2rem"
       gap="1rem"
     >
-      <Heading fontSize="lg">직업을 선택해주세요!</Heading>
+      <Heading fontSize="lg">추가 정보를 선택해주세요!</Heading>
       <Text fontSize="md" textAlign="center">
-        직업을 선택하면{' '}
+        추가 정보를 입력하면
+        <br />
         <Text as="span" color="main" fontWeight="bold">
           다독다독
         </Text>
         이 추천하는 책장을 볼 수 있어요!
       </Text>
-      <AdditionalProfileForm />
+      <AdditionalProfileForm
+        jobGroups={allJobQuery.data.jobGroups}
+        jobs={allJobQuery.data.jobs}
+      />
     </VStack>
   );
 };

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box } from '@chakra-ui/react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import useMyprofileQuery from '@/queries/user/useMyProfileQuery';
 import ProfileInfo from '@/ui/ProfileInfo';
@@ -11,9 +11,18 @@ const MyProfilePage = () => {
   const userProfileQuery = useMyprofileQuery();
   const bookshelfQuery = useMySummaryBookshlefQuery();
   const pathname = usePathname();
+  const router = useRouter();
 
   const isSuccess = userProfileQuery.isSuccess && bookshelfQuery.isSuccess;
   if (!isSuccess) return null;
+
+  const {
+    nickname,
+    job: { jobGroupName, jobName },
+  } = userProfileQuery.data;
+
+  const isSavedAdditioanlInfo = !!(nickname && jobGroupName && jobName);
+  if (!isSavedAdditioanlInfo) router.push(`${pathname}/add`);
 
   return (
     <ProfileInfo

--- a/src/constants/FormRule/index.ts
+++ b/src/constants/FormRule/index.ts
@@ -13,6 +13,10 @@ const FORM_RULES: {
       value: 10,
       message: '닉네임을 10자 이하로 입력해주세요.',
     },
+    pattern: {
+      value: /^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]{2,10}$/,
+      message: '한글, 영문, 숫자만 입력 가능해요.',
+    },
   },
   email: {
     required: '이메일을 입력해주세요',

--- a/src/queries/job/useAllJobQuery/index.ts
+++ b/src/queries/job/useAllJobQuery/index.ts
@@ -1,0 +1,25 @@
+import jobAPI from '@/apis/job';
+import { useQuery } from '@tanstack/react-query';
+import { OptionHTMLAttributes } from 'react';
+
+const useAllJobQuery = () =>
+  useQuery(['allJob'], () =>
+    jobAPI.getAllJobs().then(({ data }) => {
+      const jobGroups: OptionHTMLAttributes<HTMLOptionElement>[] = [];
+      const jobs: {
+        [index: string]: OptionHTMLAttributes<HTMLOptionElement>[];
+      } = {};
+
+      data.jobs.forEach(({ jobGroup, jobNames }) => {
+        jobGroups.push({ value: jobGroup.name, label: jobGroup.koreanName });
+        jobs[jobGroup.name] = jobNames.map(({ koreanName, name }) => ({
+          value: name,
+          label: koreanName,
+        }));
+      });
+
+      return { jobGroups, jobs };
+    })
+  );
+
+export default useAllJobQuery;

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,7 +1,25 @@
 export interface APIJob {
-  jobGroupKoreanName: string;
-  jobGroupName: string;
-  jobNameKoreanName: string | null;
-  jobName: string;
-  order: string;
+  jobGroupKoreanName: APIJobGroup['koreanName'];
+  jobGroupName: APIJobGroup['name'];
+  jobNameKoreanName: APIJobName['koreanName'] | null;
+  jobName: APIJobName['name'];
+  order: APIJobName['order'];
+}
+
+export interface APIJobGroup {
+  koreanName: string;
+  name: string;
+}
+
+export interface APIJobName {
+  koreanName: string;
+  name: string;
+  order: number;
+}
+
+export interface APIAllJob {
+  jobs: {
+    jobGroup: APIJobGroup;
+    jobNames: APIJobName[];
+  }[];
 }

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,7 +1,7 @@
 export interface APIJob {
-  jobGroupKoreanName: string | null;
-  jobGroupName: string | null;
+  jobGroupKoreanName: string;
+  jobGroupName: string;
   jobNameKoreanName: string | null;
-  jobName: string | null;
-  order: string | null;
+  jobName: string;
+  order: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,7 +3,8 @@ import { APIJob } from './job';
 export interface APIUser {
   userId: number;
   name: string | null;
-  nickname: string;
+  nickname: string | null;
+  oauthNickname: string;
   email: string | null;
   profileImage: string;
   gender: true;

--- a/src/ui/AdditionalProfileForm/index.tsx
+++ b/src/ui/AdditionalProfileForm/index.tsx
@@ -1,24 +1,21 @@
 import { Box, useTheme, VStack } from '@chakra-ui/react';
-import type { OptionHTMLAttributes } from 'react';
+import { OptionHTMLAttributes } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import FormInput from '../FormInput';
 import FormSelect from '../FormSelect';
 
-const AdditionalProfileForm = () => {
-  const theme = useTheme();
-
-  const jobGroups: OptionHTMLAttributes<HTMLOptionElement>[] = [];
-  const jobs: {
+interface AdditionalProfileFormProps {
+  jobGroups: OptionHTMLAttributes<HTMLOptionElement>[];
+  jobs: {
     [index: string]: OptionHTMLAttributes<HTMLOptionElement>[];
-  } = {};
+  };
+}
 
-  // TODO: API 연결
-  API_JOBS_RESPONSE.jobs.forEach(({ jobGroup, jobNames }) => {
-    jobGroups.push({ value: jobGroup.name, label: jobGroup.koreanName });
-    jobs[jobGroup.name] = jobNames.map(({ koreanName, name }) => ({
-      value: name,
-      label: koreanName,
-    }));
-  });
+const AdditionalProfileForm = ({
+  jobGroups,
+  jobs,
+}: AdditionalProfileFormProps) => {
+  const theme = useTheme();
 
   const onSubmit: Parameters<typeof methods.handleSubmit>[0] = ({
     jobGroup,
@@ -37,6 +34,7 @@ const AdditionalProfileForm = () => {
     <FormProvider {...methods}>
       <Box as="form" w="100%" onSubmit={methods.handleSubmit(onSubmit)}>
         <VStack gap="1rem">
+          <FormInput label="닉네임" name="nickname" />
           <FormSelect label="직군" name="jobGroup" options={jobGroups} />
           <FormSelect
             label="직업"
@@ -68,283 +66,3 @@ const AdditionalProfileForm = () => {
 };
 
 export default AdditionalProfileForm;
-
-const API_JOBS_RESPONSE = {
-  jobs: [
-    {
-      jobGroup: {
-        koreanName: '개발',
-        name: 'DEVELOPMENT',
-      },
-      jobNames: [
-        {
-          koreanName: '데이터 엔지니어',
-          name: 'DATA_ENGINEER',
-          order: 1,
-        },
-        {
-          koreanName: '자바 개발자',
-          name: 'JAVA_DEVELOPER',
-          order: 2,
-        },
-        {
-          koreanName: '.NET 개발자',
-          name: 'DOTNET_DEVELOPER',
-          order: 3,
-        },
-        {
-          koreanName: '시스템,네트워크 관리자',
-          name: 'SYSTEM_NETWORK_ADMINISTRATOR',
-          order: 4,
-        },
-        {
-          koreanName: '백엔드 개발자',
-          name: 'BACKEND_DEVELOPER',
-          order: 5,
-        },
-        {
-          koreanName: '프론트엔드 개발자',
-          name: 'FRONTEND_DEVELOPER',
-          order: 6,
-        },
-        {
-          koreanName: '보안 엔지니어',
-          name: 'SECURITY_ENGINEER',
-          order: 7,
-        },
-        {
-          koreanName: '하드웨어 엔지니어',
-          name: 'HARDWARE_ENGINEER',
-          order: 8,
-        },
-        {
-          koreanName: 'DevOps / 시스템 관리자',
-          name: 'DEVOPS',
-          order: 9,
-        },
-        {
-          koreanName: '기타',
-          name: 'ETC',
-          order: 10,
-        },
-      ],
-    },
-    {
-      jobGroup: {
-        koreanName: '경영/비즈니스',
-        name: 'MANAGEMENT_BUSINESS',
-      },
-      jobNames: [
-        {
-          koreanName: '비서',
-          name: 'SECRETARY',
-          order: 1,
-        },
-        {
-          koreanName: '운영 매니저',
-          name: 'OPERATION_MANAGER',
-          order: 2,
-        },
-        {
-          koreanName: '오피스 관리 / 매니저',
-          name: 'OFFICE_MANAGER',
-          order: 3,
-        },
-        {
-          koreanName: 'PM/PO',
-          name: 'PM_PO',
-          order: 4,
-        },
-        {
-          koreanName: '사업개발/기획자',
-          name: 'BUSINESS_PLANNER',
-          order: 5,
-        },
-        {
-          koreanName: '서비스 기획자',
-          name: 'SERVICE_PLANNER',
-          order: 6,
-        },
-        {
-          koreanName: '컨설턴트',
-          name: 'CONSULTANT',
-          order: 7,
-        },
-        {
-          koreanName: 'CEO,Chief Executive Officer',
-          name: 'CEO',
-          order: 8,
-        },
-        {
-          koreanName: 'CFO,Chief Financial Officer',
-          name: 'CFO',
-          order: 9,
-        },
-        {
-          koreanName: '기타',
-          name: 'ETC',
-          order: 10,
-        },
-      ],
-    },
-    {
-      jobGroup: {
-        koreanName: '마케팅/광고',
-        name: 'MARKETING_ADVERTISEMENT',
-      },
-      jobNames: [
-        {
-          koreanName: '브랜드 마케터',
-          name: 'BRAND_MARKETER',
-          order: 1,
-        },
-        {
-          koreanName: '카피라이터',
-          name: 'COPYWRITER',
-          order: 2,
-        },
-        {
-          koreanName: '마케터',
-          name: 'MARKETER',
-          order: 3,
-        },
-        {
-          koreanName: 'PR 전문가',
-          name: 'PR_EXPERT',
-          order: 4,
-        },
-        {
-          koreanName: '마케팅 전략 기획자',
-          name: 'MARKETING_PLANNER',
-          order: 5,
-        },
-        {
-          koreanName: '소셜 마케터',
-          name: 'SOCIAL_MEDIA_MARKETER',
-          order: 6,
-        },
-        {
-          koreanName: '광고 기획자(AE)',
-          name: 'ADVERTISING_PLANNER_AE',
-          order: 7,
-        },
-        {
-          koreanName: 'CMO,Chief Marketing Officer',
-          name: 'CMO',
-          order: 8,
-        },
-        {
-          koreanName: 'CBO,Chief Brand Officer',
-          name: 'CBO',
-          order: 9,
-        },
-        {
-          koreanName: '기타',
-          name: 'ETC',
-          order: 10,
-        },
-      ],
-    },
-    {
-      jobGroup: {
-        koreanName: '영업',
-        name: 'SALES',
-      },
-      jobNames: [
-        {
-          koreanName: '영업',
-          name: 'SALES',
-          order: 1,
-        },
-        {
-          koreanName: '주요고객사 담당자',
-          name: 'KEY_ACCOUNT_MANAGER',
-          order: 2,
-        },
-        {
-          koreanName: '세일즈 엔지니어',
-          name: 'SALES_ENGINEER',
-          order: 3,
-        },
-        {
-          koreanName: '영업 관리자',
-          name: 'SALES_MANAGER',
-          order: 4,
-        },
-        {
-          koreanName: '솔루션 컨설턴트',
-          name: 'SOLUTION_CONSULTANT',
-          order: 5,
-        },
-        {
-          koreanName: '고객성공매니저',
-          name: 'CUSTOMER_SUCCESS_MANAGER',
-          order: 6,
-        },
-        {
-          koreanName: '기타',
-          name: 'ETC',
-          order: 7,
-        },
-      ],
-    },
-    {
-      jobGroup: {
-        koreanName: '고객서비스 / 리테일',
-        name: 'CUSTOMER_SERVICE_RETAIL',
-      },
-      jobNames: [
-        {
-          koreanName: 'CS 어드바이저',
-          name: 'CS_ADVISOR',
-          order: 1,
-        },
-        {
-          koreanName: '승무원',
-          name: 'FLIGHT_ATTENDANT',
-          order: 2,
-        },
-        {
-          koreanName: 'AS 기술자',
-          name: 'AS_TECHNICIAN',
-          order: 3,
-        },
-        {
-          koreanName: '이벤트 기획자',
-          name: 'EVENT_PLANNER',
-          order: 4,
-        },
-        {
-          koreanName: '플로리스트',
-          name: 'FLORIST',
-          order: 5,
-        },
-        {
-          koreanName: '여행 에이전트',
-          name: 'TRAVEL_AGENT',
-          order: 6,
-        },
-        {
-          koreanName: '매장 관리자',
-          name: 'STORE_MANAGER',
-          order: 7,
-        },
-        {
-          koreanName: '매장점원',
-          name: 'STORE_STAFF',
-          order: 8,
-        },
-        {
-          koreanName: '피부관리사',
-          name: 'SKIN_CARE_SPECIALIST',
-          order: 9,
-        },
-        {
-          koreanName: '기타',
-          name: 'ETC',
-          order: 10,
-        },
-      ],
-    },
-  ],
-};

--- a/src/ui/AdditionalProfileForm/index.tsx
+++ b/src/ui/AdditionalProfileForm/index.tsx
@@ -58,7 +58,7 @@ const AdditionalProfileForm = ({
             border: '1px solid',
           }}
         >
-          가입 완료
+          저장
         </Box>
       </Box>
     </FormProvider>

--- a/src/ui/CreateMeeting/CreateMeetingForm/index.tsx
+++ b/src/ui/CreateMeeting/CreateMeetingForm/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, useTheme } from '@chakra-ui/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import UserInput from '@/ui/FormInput';
+import FormInput from '@/ui/FormInput';
 
 const CreateMeetingForm = () => {
   const methods = useForm({
@@ -50,11 +50,11 @@ const CreateMeetingForm = () => {
         onSubmit={methods.handleSubmit(handleInputSubmit)}
       >
         <Flex direction="column" gap="2rem" align="center">
-          <UserInput label="모임제목" name="meetingTitle" />
-          <UserInput label="모임설명" name="meetingExplanation" />
-          <UserInput label="모임인원" name="meetingPersonnelNumber" />
-          <UserInput label="모임 시작일" name="meetingStartDate" type="date" />
-          <UserInput label="모임 종료일" name="meetingEndDate" type="date" />
+          <FormInput label="모임제목" name="meetingTitle" />
+          <FormInput label="모임설명" name="meetingExplanation" />
+          <FormInput label="모임인원" name="meetingPersonnelNumber" />
+          <FormInput label="모임 시작일" name="meetingStartDate" type="date" />
+          <FormInput label="모임 종료일" name="meetingEndDate" type="date" />
         </Flex>
         <Box
           as="button"

--- a/src/ui/FormInput/index.tsx
+++ b/src/ui/FormInput/index.tsx
@@ -14,13 +14,13 @@ import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { MouseEvent, TouchEvent, HTMLInputTypeAttribute } from 'react';
 
-interface UserInputProps {
+interface FormInputProps {
   label: string;
   name: string;
   type?: HTMLInputTypeAttribute;
 }
 
-const FormInput = ({ label, name, type = 'text' }: UserInputProps) => {
+const FormInput = ({ label, name, type = 'text' }: FormInputProps) => {
   const theme = useTheme();
   const { colors } = theme;
 
@@ -83,7 +83,12 @@ const FormInput = ({ label, name, type = 'text' }: UserInputProps) => {
               onTouchEnd={onClearButtonClick}
               tabIndex={-1}
             >
-              <CloseIcon width="1.5rem" fill={colors.black['800']} />
+              <CloseIcon
+                fill={colors.black['800']}
+                width="16"
+                height="16"
+                viewBox="0,0,24,24"
+              />
             </button>
           </InputRightElement>
         )}

--- a/src/ui/FormInput/index.tsx
+++ b/src/ui/FormInput/index.tsx
@@ -20,7 +20,7 @@ interface UserInputProps {
   type?: HTMLInputTypeAttribute;
 }
 
-const UserInput = ({ label, name, type = 'text' }: UserInputProps) => {
+const FormInput = ({ label, name, type = 'text' }: UserInputProps) => {
   const theme = useTheme();
   const { colors } = theme;
 
@@ -95,4 +95,4 @@ const UserInput = ({ label, name, type = 'text' }: UserInputProps) => {
   );
 };
 
-export default UserInput;
+export default FormInput;

--- a/src/ui/ProfileInfo/index.tsx
+++ b/src/ui/ProfileInfo/index.tsx
@@ -15,15 +15,15 @@ const ProfileInfo = ({
   summaryBookshelf: APISummaryBookshelf;
   children?: ReactNode;
 }) => {
-  const { nickname, profileImage, email, job } = user;
+  const { nickname, oauthNickname, profileImage, email, job } = user;
   const { jobGroupKoreanName, jobNameKoreanName } = job;
   const { bookshelfName, books } = summaryBookshelf;
   return (
     <Flex direction="column" justify="center" gap="2rem" pt="4rem" px="2rem">
       <Flex width="100%" gap="1.5rem">
-        <Avatar src={profileImage} name={nickname} w="8rem" h="8rem" />
+        <Avatar src={profileImage} w="8rem" h="8rem" />
         <Flex direction="column" justify="center">
-          <Text fontSize="xl">{nickname}</Text>
+          <Text fontSize="xl">{nickname || oauthNickname}</Text>
           <Text fontSize="sm">{email}</Text>
         </Flex>
       </Flex>


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

* 내 프로필을 조회할 때 닉네임이나 직업 정보가 존재하지 않는 경우 추가 정보 입력 페이지로 리다이렉트 시킵니다.
* 모든 직업정보 조회 API를 연동하여 직군, 직업 목록을 서버에서 받아옵니다.
* 직업관련 타입을 수정했습니다.
* submit 이벤트는 아직 구현되지 않았습니다.

# 스크린샷

<img src="https://user-images.githubusercontent.com/48359052/222984233-b6cd2271-7623-4212-922e-af71572addff.png" width=300 />

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

* 직업과 관련된 response를 수정 요청 해둔 상태입니다.

# 관련 이슈

- Close #73 
