### PR TITLE
[#79] useAuth 훅, AuthRequired 구현

### DIFF
--- a/src/app/login/redirect/page.tsx
+++ b/src/app/login/redirect/page.tsx
@@ -4,23 +4,22 @@ import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { Flex, Spinner } from '@chakra-ui/react';
 
-import localStorage from '@/utils/storage';
-import { ACCESS_TOKEN_STORAGE_KEY } from '@/constants';
+import { useAuth } from '@/hooks/auth';
 
 const RedirectPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const accessToken = searchParams.get('access_token');
+  const { setAuth } = useAuth();
 
   useEffect(() => {
     const isAuthed = !!accessToken;
-    const storage = localStorage(ACCESS_TOKEN_STORAGE_KEY);
 
     if (isAuthed) {
-      storage.set(accessToken);
-      router.push('/bookarchive');
+      setAuth(accessToken);
+      router.replace('/bookarchive');
     }
-  }, [accessToken, router]);
+  });
 
   return (
     <Flex align="center" justify="center" height="95vh">

--- a/src/hooks/auth/atoms/index.ts
+++ b/src/hooks/auth/atoms/index.ts
@@ -1,0 +1,33 @@
+import { atom, useRecoilState, useResetRecoilState } from 'recoil';
+
+import tokenStorage from '@/utils/storage';
+import { ACCESS_TOKEN_STORAGE_KEY } from '@/constants/index';
+
+const accessTokenAtom = atom<string | null>({
+  key: 'accessToken',
+  default: null,
+  effects: [
+    ({ setSelf }) => {
+      const storage =
+        typeof window !== 'undefined'
+          ? tokenStorage(ACCESS_TOKEN_STORAGE_KEY)
+          : undefined;
+
+      if (!storage) {
+        return;
+      }
+
+      const defaultToken = storage.get();
+      const isAuthorized = () => !!defaultToken;
+
+      if (isAuthorized()) {
+        setSelf(defaultToken);
+      }
+    },
+  ],
+});
+
+const useAccessToken = () => useRecoilState(accessTokenAtom);
+const useResetAccessToken = () => useResetRecoilState(accessTokenAtom);
+
+export { useAccessToken, useResetAccessToken };

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,0 +1,1 @@
+export { default as useAuth } from './useAuth';

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useAccessToken, useResetAccessToken } from './atoms';
+
+import tokenStorage from '@/utils/storage';
+import { ACCESS_TOKEN_STORAGE_KEY } from '@/constants';
+
+const useAuth = () => {
+  const storage = tokenStorage(ACCESS_TOKEN_STORAGE_KEY);
+  const [accessToken, setAccessToken] = useAccessToken();
+  const [isAuthed, setIsAuthed] = useState(!!accessToken);
+  const resetAccessToken = useResetAccessToken();
+
+  const setAuth = (newToken: string) => {
+    storage.set(newToken);
+    setAccessToken(newToken);
+  };
+
+  const removeAuth = () => {
+    storage.remove();
+    resetAccessToken();
+  };
+
+  useEffect(() => {
+    setIsAuthed(!!accessToken);
+  }, [accessToken]);
+
+  return {
+    isAuthed,
+    setAuth,
+    removeAuth,
+  };
+};
+
+export default useAuth;

--- a/src/ui/AuthRequired/index.tsx
+++ b/src/ui/AuthRequired/index.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+
+import { useAuth } from '@/hooks/auth';
+import { useRouter } from 'next/navigation';
+
+const AuthRequired = ({ children }: { children: ReactNode }) => {
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+  const { isAuthed } = useAuth();
+
+  useEffect(() => {
+    setMounted(true);
+
+    if (!isAuthed) {
+      router.replace('/login');
+    }
+  }, [isAuthed, router]);
+
+  return <>{mounted && isAuthed && children}</>;
+};
+
+export default AuthRequired;


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
## 1. useAuth 훅
- acessToken은 Recoil로 관리됩니다.
  - 새로고침 시 localStorage에 저장된 token 값을 가져옵니다.
- Auth 관련 hook(useAuth)을 작성했습니다.
- login 시 useAuth 훅을 사용하도록 수정했습니다.

이름 | 타입 | 역할
-- | -- | --
isAuthed | boolean | accessToken의 유무에 따라 인증된 상태인지 아닌지를 반환합니다.
setAuth | 함수 | 새로운 accessToken을 저장하기 위한 함수입니다. (로그인 시 사용)
removeAuth | 함수 | 관리되고 있는 accessToken을 삭제합니다. (로그아웃 시 사용)

아래와 같이 import해서 사용하시면 됩니다!
```ts
import { useAuth } from '@/hooks/auth';

const { isAuthed, setAuth, removeAuth } = useAuth();
...
```

## 2. AuthRequired
로그인 후 사용되어야하는 페이지인 경우, `AuthRequired`를 감싸주세요!
login 페이지로 replace됩니다.

```ts
import AuthRequired from '@/ui/AuthRequired';

const Page = () => {
 
  return (
    <AuthRequired>
      ...
    </AuthRequired>
  );
};

export default Page;
```

# Help
- 사용하는데 불편할 것 같은 부분이 있다면 말씀해주세요!!

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #79  <!--이슈번호-->
