### PR TITLE
[#94] 로그인하지 않은 사용자 프로필 페이지 접근 못하도록 수정

### DIFF
--- a/src/app/profile/me/layout.tsx
+++ b/src/app/profile/me/layout.tsx
@@ -1,0 +1,7 @@
+import AuthRequired from '@/ui/AuthRequired';
+
+const Layout = ({ children }: { children: React.ReactNode }) => {
+  return <AuthRequired>{children}</AuthRequired>;
+};
+
+export default Layout;

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -22,8 +22,8 @@ const MyProfilePage = () => {
       nickname,
       job: { jobGroupName, jobName },
     } = userProfileQuery.data;
-    const isSavedAdditioanlInfo = !!(nickname && jobGroupName && jobName);
-    if (!isSavedAdditioanlInfo) router.replace(`${pathname}/add`);
+    const isSavedAdditionalInfo = !!(nickname && jobGroupName && jobName);
+    if (!isSavedAdditionalInfo) router.replace(`${pathname}/add`);
   }, [userProfileQuery, isSuccess, pathname, router]);
 
   if (!isSuccess) return null;

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import useMyprofileQuery from '@/queries/user/useMyProfileQuery';
 import ProfileInfo from '@/ui/ProfileInfo';
 import useMySummaryBookshlefQuery from '@/queries/bookshelf/useMySummaryBookshelfQuery';
+import { useEffect } from 'react';
 
 const MyProfilePage = () => {
   const userProfileQuery = useMyprofileQuery();
@@ -14,15 +15,18 @@ const MyProfilePage = () => {
   const router = useRouter();
 
   const isSuccess = userProfileQuery.isSuccess && bookshelfQuery.isSuccess;
+
+  useEffect(() => {
+    if (!isSuccess) return;
+    const {
+      nickname,
+      job: { jobGroupName, jobName },
+    } = userProfileQuery.data;
+    const isSavedAdditioanlInfo = !!(nickname && jobGroupName && jobName);
+    if (!isSavedAdditioanlInfo) router.replace(`${pathname}/add`);
+  }, [userProfileQuery, isSuccess, pathname, router]);
+
   if (!isSuccess) return null;
-
-  const {
-    nickname,
-    job: { jobGroupName, jobName },
-  } = userProfileQuery.data;
-
-  const isSavedAdditioanlInfo = !!(nickname && jobGroupName && jobName);
-  if (!isSavedAdditioanlInfo) router.push(`${pathname}/add`);
 
   return (
     <ProfileInfo

--- a/src/ui/BottomNavigation/NavigationItem/index.tsx
+++ b/src/ui/BottomNavigation/NavigationItem/index.tsx
@@ -1,13 +1,14 @@
 import { Box, Flex, Text, useTheme } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import type { SVGProps } from 'react';
+import type { MouseEvent, SVGProps } from 'react';
 
 interface NavigationItemPorps {
   iconName: string;
   label: string;
   href: string;
   isActive: boolean;
+  onClick?: (event: MouseEvent) => void;
 }
 
 const NavigationItem = ({
@@ -15,6 +16,7 @@ const NavigationItem = ({
   label,
   href,
   isActive,
+  onClick,
 }: NavigationItemPorps) => {
   const theme = useTheme();
   const color = isActive ? theme.colors.main : theme.colors.black['900'];
@@ -24,7 +26,7 @@ const NavigationItem = ({
   );
 
   return (
-    <Link href={href}>
+    <Link onClick={onClick} href={href}>
       <Flex
         direction="column"
         justify="center"

--- a/src/ui/BottomNavigation/index.tsx
+++ b/src/ui/BottomNavigation/index.tsx
@@ -1,59 +1,74 @@
 'use client';
 
-import { Flex } from '@chakra-ui/react';
+import { useAuth } from '@/hooks/auth';
+import { Flex, useDisclosure } from '@chakra-ui/react';
 import { usePathname } from 'next/navigation';
+import type { MouseEvent } from 'react';
+import LoginBottomSheet from '../LoginBottomSheet';
 import NavigationItem from './NavigationItem';
-
-const navigationItems = [
-  {
-    iconName: 'bookshelf',
-    label: '북카이브',
-    href: '/bookarchive/',
-  },
-  {
-    iconName: 'hashtag',
-    label: '도서 검색',
-    href: '/book/',
-  },
-  {
-    iconName: 'book',
-    label: '독서 모임',
-    href: '/meeting/',
-  },
-  {
-    iconName: 'user',
-    label: '내 프로필',
-    href: '/profile/me/',
-  },
-];
 
 const BottomNavigation = () => {
   const pathname = usePathname();
 
+  const { isAuthed } = useAuth();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const navigationItems = [
+    {
+      iconName: 'bookshelf',
+      label: '북카이브',
+      href: '/bookarchive/',
+    },
+    {
+      iconName: 'hashtag',
+      label: '도서 검색',
+      href: '/book/',
+    },
+    {
+      iconName: 'book',
+      label: '독서 모임',
+      href: '/meeting/',
+    },
+    {
+      iconName: 'user',
+      label: '내 프로필',
+      href: '/profile/me/',
+      onClick: (event: MouseEvent) => {
+        if (isAuthed) return;
+        onOpen();
+        event.preventDefault();
+      },
+    },
+  ];
+
   return (
-    <Flex
-      justify="space-between"
-      bg="white.900"
-      px="3.2rem"
-      py="1.6rem"
-      pos="fixed"
-      bottom={0}
-      w="100%"
-      maxW="43rem"
-      borderTopRadius={20}
-      boxShadow="rgba(0, 0, 0, 0.05) 0px 0px 10px 1px"
-      maxH="9rem"
-    >
-      {navigationItems.map(({ iconName, label, href }) => (
-        <NavigationItem
-          key={href}
-          iconName={iconName}
-          label={label}
-          href={href}
-          isActive={pathname?.indexOf(href) === 0}
-        />
-      ))}
-    </Flex>
+    <>
+      <Flex
+        justify="space-between"
+        bg="white.900"
+        px="3.2rem"
+        py="1.6rem"
+        pos="fixed"
+        bottom={0}
+        w="100%"
+        maxW="43rem"
+        borderTopRadius={20}
+        boxShadow="rgba(0, 0, 0, 0.05) 0px 0px 10px 1px"
+        maxH="9rem"
+      >
+        {navigationItems.map(({ iconName, label, href, onClick }) => (
+          <NavigationItem
+            key={href}
+            iconName={iconName}
+            label={label}
+            href={href}
+            isActive={pathname?.indexOf(href) === 0}
+            onClick={onClick}
+          />
+        ))}
+      </Flex>
+      <LoginBottomSheet isOpen={isOpen} onClose={onClose} />
+    </>
   );
 };
 

--- a/src/ui/LoginBottomSheet/index.tsx
+++ b/src/ui/LoginBottomSheet/index.tsx
@@ -7,6 +7,7 @@ import BottomSheet from '@/ui/common/BottomSheet';
 import IconButton from '@/ui/common/IconButton';
 import Button from '@/ui/common/Button';
 import Logo from '@/ui/common/Logo';
+import Link from 'next/link';
 
 interface Props {
   isOpen: boolean;
@@ -14,6 +15,8 @@ interface Props {
 }
 
 const LoginBottomSheet = ({ isOpen, onClose }: Props) => {
+  const kakaoUrl = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
+
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose}>
       <Flex direction="column" align="center" gap="3rem" p="3rem 3rem 4rem">
@@ -32,16 +35,18 @@ const LoginBottomSheet = ({ isOpen, onClose }: Props) => {
             다독다독의 다양한 서비스를 이용해보세요!
           </Highlight>
         </Text>
-        <Button scheme="kakao" fullWidth>
-          <Image
-            src="/images/kakao.svg"
-            alt="카카오 로고"
-            width={21}
-            height={19}
-            priority
-          />
-          카카오 로그인
-        </Button>
+        <Link href={kakaoUrl} style={{ width: '100%' }}>
+          <Button scheme="kakao" fullWidth>
+            <Image
+              src="/images/kakao.svg"
+              alt="카카오 로고"
+              width={21}
+              height={19}
+              priority
+            />
+            카카오 로그인
+          </Button>
+        </Link>
       </Flex>
     </BottomSheet>
   );


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

* 로그인하지 않은 사용자는 프로필 페이지로 접근할 수 없도록 수정해두었습니다.
* 바텀 네비게이션에서 프로필 페이지로 접근하려하면 바텀 시트를 띄워줍니다.

# 스크린샷

<!-- 없는 경우 생략한다. -->

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #94 
