### PR TITLE
[#128] 모임 상세 페이지 댓글 리스트 API 연동

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -1,6 +1,7 @@
 import { APIEntireMeetingList } from '@/types/meeting';
-import { publicApi } from '../core/axios';
+import { APIMeetingDetailCommentsList } from '@/types/meetingDetailCommentsList';
 import { APIMeetingGroup } from '@/types/meeting';
+import { publicApi } from '../core/axios';
 import { APIMeetingDetail } from '@/types/meetingDetail';
 
 const MeetingAPI = {
@@ -17,6 +18,21 @@ const MeetingAPI = {
   }: {
     bookGroupId: APIMeetingGroup['bookGroupId'];
   }) => publicApi.get<APIMeetingDetail>(`/api/book-groups/${bookGroupId}`),
+  getMeetingDetailCommentsList: ({
+    bookGroupId,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+  }) =>
+    publicApi.get<APIMeetingDetailCommentsList>(
+      `/api/book-groups/${bookGroupId}/comments`,
+      {
+        params: {
+          groupCommentCursorId: 100,
+          pageSize: 10,
+          sortDirection: 'DESC',
+        },
+      }
+    ),
 };
 
 export default MeetingAPI;

--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -1,8 +1,11 @@
-import { APICreateMeetingReqeust, APIEntireMeetingList, APIMeetingGroup } from '@/types/meeting';
-import { APIMeetingDetailCommentsList } from '@/types/meetingDetailCommentsList';
-import { APIMeetingDetail } from '@/types/meetingDetail';
-import { APIMeetingGroup } from '@/types/meeting';
-import { publicApi } from '../core/axios';
+import {
+  APICreateMeetingReqeust,
+  APIEntireMeetingList,
+  APIMeetingGroup,
+} from "@/types/meeting";
+import { APIMeetingDetailCommentsList } from "@/types/meetingDetailCommentsList";
+import { APIMeetingDetail } from "@/types/meetingDetail";
+import { publicApi } from "../core/axios";
 
 const MeetingAPI = {
   getEntireMeetingList: () =>
@@ -10,23 +13,23 @@ const MeetingAPI = {
       params: {
         pageSize: 10,
         groupCursorId: 999,
-        sortDirection: 'DESC',
+        sortDirection: "DESC",
       },
     }),
 
   createMeeting: ({ meeting }: { meeting: APICreateMeetingReqeust }) =>
-    publicApi.post('/api/book-groups', meeting),
+    publicApi.post("/api/book-groups", meeting),
 
   getMeetingDetailInfo: ({
     bookGroupId,
   }: {
-    bookGroupId: APIMeetingGroup['bookGroupId'];
+    bookGroupId: APIMeetingGroup["bookGroupId"];
   }) => publicApi.get<APIMeetingDetail>(`/api/book-groups/${bookGroupId}`),
 
   getMeetingDetailCommentsList: ({
     bookGroupId,
   }: {
-    bookGroupId: APIMeetingGroup['bookGroupId'];
+    bookGroupId: APIMeetingGroup["bookGroupId"];
   }) =>
     publicApi.get<APIMeetingDetailCommentsList>(
       `/api/book-groups/${bookGroupId}/comments`,
@@ -34,7 +37,7 @@ const MeetingAPI = {
         params: {
           groupCommentCursorId: 100,
           pageSize: 10,
-          sortDirection: 'DESC',
+          sortDirection: "DESC",
         },
       }
     ),

--- a/src/queries/meeting/useMeetingCommentsQuery/index.tsx
+++ b/src/queries/meeting/useMeetingCommentsQuery/index.tsx
@@ -1,0 +1,16 @@
+import MeetingAPI from '@/apis/Meeting';
+import { APIMeetingDetail } from '@/types/meetingDetail';
+import { useQuery } from '@tanstack/react-query';
+
+const useMeetingCommentsQuery = ({
+  bookGroupId,
+}: {
+  bookGroupId: APIMeetingDetail['bookGroupId'];
+}) =>
+  useQuery(['entireMeetingList', bookGroupId], () =>
+    MeetingAPI.getMeetingDetailCommentsList({ bookGroupId }).then(
+      response => response.data
+    )
+  );
+
+export default useMeetingCommentsQuery;

--- a/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
+++ b/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
@@ -1,0 +1,9 @@
+import MeetingAPI from '@/apis/Meeting';
+import { useQuery } from '@tanstack/react-query';
+
+const useEntireMeetingListQuery = () =>
+  useQuery(['entireMeetingList'], () =>
+    MeetingAPI.getEntireMeetingList().then(response => response.data)
+  );
+
+export default useEntireMeetingListQuery;

--- a/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
+++ b/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
@@ -1,9 +1,0 @@
-import MeetingAPI from '@/apis/Meeting';
-import { useQuery } from '@tanstack/react-query';
-
-const useEntireMeetingListQuery = () =>
-  useQuery(['entireMeetingList'], () =>
-    MeetingAPI.getEntireMeetingList().then(response => response.data)
-  );
-
-export default useEntireMeetingListQuery;

--- a/src/queries/meeting/useMeetingInfoQuery/index.tsx
+++ b/src/queries/meeting/useMeetingInfoQuery/index.tsx
@@ -2,16 +2,14 @@ import MeetingAPI from '@/apis/Meeting';
 import { useQuery } from '@tanstack/react-query';
 import { APIMeetingDetail } from '@/types/meetingDetail';
 
-const useMeetingDetailInfoQuery = ({
+const useMeetingInfoQuery = ({
   bookGroupId,
 }: {
   bookGroupId: APIMeetingDetail['bookGroupId'];
 }) => {
   return useQuery(['meetingDetailInfo', bookGroupId], () =>
-    MeetingAPI.getMeetingDetailInfo({ bookGroupId }).then(
-      ({data}) => data
-    )
+    MeetingAPI.getMeetingDetailInfo({ bookGroupId }).then(({ data }) => data)
   );
 };
 
-export default useMeetingDetailInfoQuery;
+export default useMeetingInfoQuery;

--- a/src/types/meetingDetailCommentsList.ts
+++ b/src/types/meetingDetailCommentsList.ts
@@ -3,15 +3,13 @@ export interface APIDateAt {
   modifiedAt: number;
 }
 
-export interface APIBookGroupComments {
+export interface APIBookGroupComments extends APIDateAt {
   commentId: number;
   contents: string;
   bookGroupId: number;
   parentCommentId: number;
   userId: number;
   userProfileImage: string;
-  createdAt: APIDateAt[];
-  modifiedAt: APIDateAt[];
 }
 
 export interface APIMeetingDetailCommentsList {

--- a/src/types/meetingDetailCommentsList.ts
+++ b/src/types/meetingDetailCommentsList.ts
@@ -1,0 +1,24 @@
+export interface APIDateAt {
+  createdAt: number;
+  modifiedAt: number;
+}
+
+export interface APIBookGroupComments {
+  commentId: number;
+  contents: string;
+  bookGroupId: number;
+  parentCommentId: number;
+  userId: number;
+  userProfileImage: string;
+  createdAt: APIDateAt[];
+  modifiedAt: APIDateAt[];
+}
+
+export interface APIBookGroupCommentsReference {
+  isFirst: boolean;
+  isLast: boolean;
+  hasNext: boolean;
+  count: number;
+  isEmpty: boolean;
+  bookGroupComments: APIBookGroupComments[];
+}

--- a/src/types/meetingDetailCommentsList.ts
+++ b/src/types/meetingDetailCommentsList.ts
@@ -14,7 +14,7 @@ export interface APIBookGroupComments {
   modifiedAt: APIDateAt[];
 }
 
-export interface APIBookGroupCommentsReference {
+export interface APIMeetingDetailCommentsList {
   isFirst: boolean;
   isLast: boolean;
   hasNext: boolean;

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -2,16 +2,10 @@ import { Avatar, Box, Flex } from '@chakra-ui/react';
 
 import CommentDeleteModal from '../CommentDeleteModal';
 import CommentModifyModal from '../CommentModifyModal';
+import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
 
-interface CommentsListDataProps {
-  id: number;
-  avatarURL: string;
-  nickName: string;
-  contents: string;
-  isWrittenUser: boolean;
-}
 interface commentsListProps {
-  commentsListData: CommentsListDataProps[];
+  commentsListData: APIBookGroupComments[];
   handleDeleteCommentBtnClick: () => void;
   handleModifyCommentBtnClick: (modifiedComment: string) => void;
 }
@@ -21,55 +15,73 @@ const CommentsList = ({
   handleDeleteCommentBtnClick,
   handleModifyCommentBtnClick,
 }: commentsListProps) => {
+  const isWrittenUser = true;
+
   return (
     <Box mt="1.5rem">
       <Box fontSize="lg" fontWeight={700}>
         댓글
       </Box>
       <Box>
-        {commentsListData.map(comment => {
-          return (
-            <Box
-              key={comment.id}
-              mt="1rem"
-              p="1rem"
-              bgColor="white"
-              borderRadius="1.5rem"
-              boxShadow="default"
-            >
-              <Flex mb="0.5rem" justify="space-between">
-                <Flex>
-                  <Avatar src={comment.avatarURL} loading="lazy" />
-                  <Flex align="center" fontSize="sm" ml="1rem" fontWeight={600}>
-                    {comment.nickName}
+        {commentsListData.map(
+          ({
+            commentId,
+            contents,
+            bookGroupId: _bookGroupId,
+            parentCommentId: _parentCommentId,
+            userId,
+            userProfileImage,
+            createdAt: _createdAt,
+            modifiedAt: _modifiedAt,
+          }) => {
+            return (
+              <Box
+                key={commentId}
+                mt="1rem"
+                p="1rem"
+                bgColor="white"
+                borderRadius="1.5rem"
+                boxShadow="default"
+              >
+                <Flex mb="0.5rem" justify="space-between">
+                  <Flex>
+                    <Avatar src={userProfileImage} loading="lazy" />
+                    <Flex
+                      align="center"
+                      fontSize="sm"
+                      ml="1rem"
+                      fontWeight={600}
+                    >
+                      {userId}
+                    </Flex>
+                  </Flex>
+                  <Flex align="center" pt="0.4rem">
+                    {isWrittenUser ? (
+                      <>
+                        <CommentModifyModal
+                          comment={contents}
+                          handleModifyCommentBtnClick={
+                            handleModifyCommentBtnClick
+                          }
+                        />
+                        <CommentDeleteModal
+                          handleDeleteCommentBtnClick={
+                            handleDeleteCommentBtnClick
+                          }
+                        />
+                      </>
+                    ) : (
+                      ''
+                    )}
                   </Flex>
                 </Flex>
-                <Flex align="center" pt="0.4rem">
-                  {comment.isWrittenUser ? (
-                    <>
-                      <CommentModifyModal
-                        comment={comment.contents}
-                        handleModifyCommentBtnClick={
-                          handleModifyCommentBtnClick
-                        }
-                      />
-                      <CommentDeleteModal
-                        handleDeleteCommentBtnClick={
-                          handleDeleteCommentBtnClick
-                        }
-                      />
-                    </>
-                  ) : (
-                    ''
-                  )}
-                </Flex>
-              </Flex>
-              <Box lineHeight="2.2rem" fontSize="md">
-                {comment.contents}
+                <Box lineHeight="2.2rem" fontSize="md">
+                  {contents}
+                </Box>
               </Box>
-            </Box>
-          );
-        })}
+            );
+          }
+        )}
       </Box>
     </Box>
   );

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -1,77 +1,28 @@
 'use client';
-import { useState, useEffect } from 'react';
+
 import { Flex } from '@chakra-ui/react';
 
 import MeetingInfo from '@/ui/MeetingDetail/MeetingInfo';
 import CommentInputBox from '@/ui/MeetingDetail/CommentInputBox';
 import CommentsList from '@/ui/MeetingDetail/CommentsList';
-import useMeetingDetailInfoQuery from '@/queries/meeting/useMeetingDetailInfoQuery';
-
-const DUMMY_COMMENTS_LIST_DATA = [
-  {
-    id: 1,
-    avatarURL: 'https://bit.ly/dan-abramov',
-    nickName: '김규란',
-    contents:
-      '백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세',
-    isWrittenUser: false,
-  },
-  {
-    id: 2,
-    avatarURL: 'https://bit.ly/dan-abramov',
-    nickName: '김재현',
-    contents:
-      '백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세',
-    isWrittenUser: true,
-  },
-  {
-    id: 3,
-    avatarURL: 'https://bit.ly/dan-abramov',
-    nickName: '백민종',
-    contents:
-      '백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세',
-    isWrittenUser: false,
-  },
-  {
-    id: 4,
-    avatarURL: 'https://bit.ly/dan-abramov',
-    nickName: '동해물과',
-    contents:
-      '백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 백두산이 마르고 닳도록 하느님이 보우하사 우리 나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세',
-    isWrittenUser: false,
-  },
-];
+import useMeetingInfoQuery from '@/queries/meeting/useMeetingInfoQuery';
+import useMeetingCommentsQuery from '@/queries/meeting/useMeetingCommentsQuery';
 
 interface MeetingDetailProps {
   bookGroupId: number;
 }
 
-interface commentsListDataProps {
-  id: number;
-  avatarURL: string;
-  nickName: string;
-  contents: string;
-  isWrittenUser: boolean;
-}
-
 const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
-  const [commentsListData, setCommentsListDate] = useState<
-    commentsListDataProps[]
-  >([]);
+  const meetingInfoQuery = useMeetingInfoQuery({ bookGroupId });
+  const meetingCommentsQuery = useMeetingCommentsQuery({ bookGroupId });
 
-  /* 댓글 리스트 조회 API 연동시, useEffect 삭제 예정 */
-  useEffect(() => {
-    setCommentsListDate(DUMMY_COMMENTS_LIST_DATA);
-  }, []);
-
-  const meetingDetailInfoQuery = useMeetingDetailInfoQuery({ bookGroupId });
-  const isSuccess = meetingDetailInfoQuery.isSuccess;
+  const isSuccess =
+    meetingInfoQuery.isSuccess && meetingCommentsQuery.isSuccess;
   if (!isSuccess) return null;
-
 
   const handleParticipateBtnClick = () => {
     console.log('모임에 참여했습니다.');
-    meetingDetailInfoQuery.refetch();
+    meetingInfoQuery.refetch();
     /*모임 참여 버튼 클릭시, 
       1) 모임 참여 관련 API 호출 예정
       2) 유저의 책장에 책 꽂기 API 호출 예정 
@@ -108,15 +59,15 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   return (
     <Flex px="5%" direction="column" justify="center" mt="1rem">
       <MeetingInfo
-        meetingInfoData={meetingDetailInfoQuery.data}
+        meetingInfoData={meetingInfoQuery.data}
         handleParticipateBtnClick={handleParticipateBtnClick}
       />
       <CommentInputBox
-        isPartInUser={meetingDetailInfoQuery.data.isGroupMember}
+        isPartInUser={meetingInfoQuery.data.isGroupMember}
         handleCreateCommentBtnClick={handleCreateCommentBtnClick}
       />
       <CommentsList
-        commentsListData={commentsListData}
+        commentsListData={meetingCommentsQuery.data.bookGroupComments}
         handleDeleteCommentBtnClick={handleDeleteCommentBtnClick}
         handleModifyCommentBtnClick={handleModifyCommentBtnClick}
       />


### PR DESCRIPTION
# 구현 내용

- 모임 상세 페이지 댓글 API 연동

# 스크린샷

<!-- 없는 경우 생략한다. -->

![스크린샷 2023-03-08 오전 5 00 28](https://user-images.githubusercontent.com/113018070/223538974-34191612-03dd-4de0-90b3-cf172edf6c60.png)


# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

- 현재 API 중에 nickname과 같은 정보들이 빠져있어 요청해 놓은 상태이고 그 외 부분들은 연동을 해놓았습니다.
- 현재 들어있는 DUMMY_DATA가 존재하지 않습니다.
- API 요청과 response는 정상적으로 오는것을 확인했습니다. 
- 추후 댓글 생성 API 연동 후 더미 데이터를 많이 만들어 놓겠습니다~

# 관련 이슈

- Close #128 
