### PR TITLE
[#135] 모임 참여 API 연동

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -2,10 +2,10 @@ import {
   APICreateMeetingReqeust,
   APIEntireMeetingList,
   APIMeetingGroup,
-} from "@/types/meeting";
-import { APIMeetingDetailCommentsList } from "@/types/meetingDetailCommentsList";
-import { APIMeetingDetail } from "@/types/meetingDetail";
-import { publicApi } from "../core/axios";
+} from '@/types/meeting';
+import { APIMeetingDetailCommentsList } from '@/types/meetingDetailCommentsList';
+import { APIMeetingDetail } from '@/types/meetingDetail';
+import { publicApi } from '../core/axios';
 
 const MeetingAPI = {
   getEntireMeetingList: () =>
@@ -13,23 +13,23 @@ const MeetingAPI = {
       params: {
         pageSize: 10,
         groupCursorId: 999,
-        sortDirection: "DESC",
+        sortDirection: 'DESC',
       },
     }),
 
   createMeeting: ({ meeting }: { meeting: APICreateMeetingReqeust }) =>
-    publicApi.post("/api/book-groups", meeting),
+    publicApi.post('/api/book-groups', meeting),
 
   getMeetingDetailInfo: ({
     bookGroupId,
   }: {
-    bookGroupId: APIMeetingGroup["bookGroupId"];
+    bookGroupId: APIMeetingGroup['bookGroupId'];
   }) => publicApi.get<APIMeetingDetail>(`/api/book-groups/${bookGroupId}`),
 
   getMeetingDetailCommentsList: ({
     bookGroupId,
   }: {
-    bookGroupId: APIMeetingGroup["bookGroupId"];
+    bookGroupId: APIMeetingGroup['bookGroupId'];
   }) =>
     publicApi.get<APIMeetingDetailCommentsList>(
       `/api/book-groups/${bookGroupId}/comments`,
@@ -37,7 +37,7 @@ const MeetingAPI = {
         params: {
           groupCommentCursorId: 100,
           pageSize: 10,
-          sortDirection: "DESC",
+          sortDirection: 'DESC',
         },
       }
     ),

--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -41,6 +41,16 @@ const MeetingAPI = {
         },
       }
     ),
+  postMeetingJoin: ({
+    bookGroupId,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+  }) =>
+    publicApi.post(`/api/book-groups/${bookGroupId}/join`, {
+      data: {
+        joinPassword: null,
+      },
+    }),
 };
 
 export default MeetingAPI;

--- a/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
+++ b/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
@@ -1,0 +1,9 @@
+import MeetingAPI from '@/apis/Meeting';
+import { useQuery } from '@tanstack/react-query';
+
+const useEntireMeetingListQuery = () =>
+  useQuery(['entireMeetingList'], () =>
+    MeetingAPI.getEntireMeetingList().then(response => response.data)
+  );
+
+export default useEntireMeetingListQuery;

--- a/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
+++ b/src/queries/meeting/useMeetingDetailCommentsListQuery/index.tsx
@@ -1,9 +1,0 @@
-import MeetingAPI from '@/apis/Meeting';
-import { useQuery } from '@tanstack/react-query';
-
-const useEntireMeetingListQuery = () =>
-  useQuery(['entireMeetingList'], () =>
-    MeetingAPI.getEntireMeetingList().then(response => response.data)
-  );
-
-export default useEntireMeetingListQuery;

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -7,6 +7,7 @@ import CommentInputBox from '@/ui/MeetingDetail/CommentInputBox';
 import CommentsList from '@/ui/MeetingDetail/CommentsList';
 import useMeetingInfoQuery from '@/queries/meeting/useMeetingInfoQuery';
 import useMeetingCommentsQuery from '@/queries/meeting/useMeetingCommentsQuery';
+import MeetingAPI from '@/apis/Meeting';
 
 interface MeetingDetailProps {
   bookGroupId: number;
@@ -20,15 +21,13 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
     meetingInfoQuery.isSuccess && meetingCommentsQuery.isSuccess;
   if (!isSuccess) return null;
 
-  const handleParticipateBtnClick = () => {
-    console.log('모임에 참여했습니다.');
+  const handleParticipateBtnClick = async () => {
+    try {
+      await MeetingAPI.postMeetingJoin({ bookGroupId });
+    } catch (error) {
+      console.error(error);
+    }
     meetingInfoQuery.refetch();
-    /*모임 참여 버튼 클릭시, 
-      1) 모임 참여 관련 API 호출 예정
-      2) 유저의 책장에 책 꽂기 API 호출 예정 
-      3) 모임 상세 정보 API 재호출 예정 
-      4) meetingInfoData update
-      */
   };
 
   const handleCreateCommentBtnClick = () => {


### PR DESCRIPTION
# 구현 내용

- 모임 상세 페이지 참여 버튼 클릭시 모임 참여 API 연동 및 모임 상세 조회 API refetch()

# 스크린샷

<!-- 없는 경우 생략한다. -->

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #135 
