### PR TITLE
[#138] 모임 상세 페이지 댓글 생성 API 연동

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -59,10 +59,7 @@ const MeetingAPI = {
     comment: string;
   }) =>
     publicApi.post(`/api/book-groups/${bookGroupId}/comment`, {
-      data: {
-        parentCommentId: null,
-        comment: `${comment}`,
-      },
+      comment: `${comment}`,
     }),
 };
 

--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -51,6 +51,19 @@ const MeetingAPI = {
         joinPassword: null,
       },
     }),
+  createMeetingComment: ({
+    bookGroupId,
+    comment,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+    comment: string;
+  }) =>
+    publicApi.post(`/api/book-groups/${bookGroupId}/comment`, {
+      data: {
+        parentCommentId: null,
+        comment: `${comment}`,
+      },
+    }),
 };
 
 export default MeetingAPI;

--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -59,7 +59,7 @@ const MeetingAPI = {
     comment: string;
   }) =>
     publicApi.post(`/api/book-groups/${bookGroupId}/comment`, {
-      comment: `${comment}`,
+      comment,
     }),
 };
 

--- a/src/types/meetingDetailCommentsList.ts
+++ b/src/types/meetingDetailCommentsList.ts
@@ -1,15 +1,14 @@
-export interface APIDateAt {
-  createdAt: number;
-  modifiedAt: number;
-}
-
-export interface APIBookGroupComments extends APIDateAt {
+export interface APIBookGroupComments {
   commentId: number;
   contents: string;
   bookGroupId: number;
   parentCommentId: number;
   userId: number;
   userProfileImage: string;
+  createdAt: string;
+  modifiedAt: string;
+  nickname: string;
+  writtenByCurrentUser: boolean;
 }
 
 export interface APIMeetingDetailCommentsList {

--- a/src/ui/MeetingDetail/CommentInputBox/index.tsx
+++ b/src/ui/MeetingDetail/CommentInputBox/index.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 interface CommentInputBoxProps {
   isPartInUser: boolean;
   handleCreateCommentBtnClick: (comment: string) => void;
-  userNickname: string | undefined | null;
-  userAvatar: string | undefined;
+  userNickname?: string | null;
+  userAvatar?: string;
 }
 
 const CommentInputBox = ({

--- a/src/ui/MeetingDetail/CommentInputBox/index.tsx
+++ b/src/ui/MeetingDetail/CommentInputBox/index.tsx
@@ -1,13 +1,20 @@
 import { Box, Flex, Textarea, Button, Avatar } from '@chakra-ui/react';
+import { useState } from 'react';
 interface CommentInputBoxProps {
   isPartInUser: boolean;
-  handleCreateCommentBtnClick: () => void;
+  handleCreateCommentBtnClick: (comment: string) => void;
 }
 
 const CommentInputBox = ({
   isPartInUser,
   handleCreateCommentBtnClick,
 }: CommentInputBoxProps) => {
+  const [commentValue, setCommentValue] = useState('');
+
+  const handleOnChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setCommentValue(event.target.value);
+  };
+
   return (
     <Box mt="1.5rem" h="100%">
       <Box fontSize="lg" fontWeight={700} mb="1rem">
@@ -36,6 +43,8 @@ const CommentInputBox = ({
                 : '모임에 참여해야 글을 작성할 수 있습니다.'
             }
             isDisabled={!isPartInUser}
+            value={commentValue}
+            onChange={handleOnChange}
           />
         </Box>
         <Flex justify="flex-end">
@@ -49,7 +58,8 @@ const CommentInputBox = ({
             border="0.1rem solid"
             isDisabled={!isPartInUser}
             onClick={() => {
-              handleCreateCommentBtnClick();
+              handleCreateCommentBtnClick(commentValue);
+              setCommentValue('');
             }}
           >
             작성하기

--- a/src/ui/MeetingDetail/CommentInputBox/index.tsx
+++ b/src/ui/MeetingDetail/CommentInputBox/index.tsx
@@ -3,11 +3,15 @@ import { useState } from 'react';
 interface CommentInputBoxProps {
   isPartInUser: boolean;
   handleCreateCommentBtnClick: (comment: string) => void;
+  userNickname: string | undefined | null;
+  userAvatar: string | undefined;
 }
 
 const CommentInputBox = ({
   isPartInUser,
   handleCreateCommentBtnClick,
+  userNickname,
+  userAvatar,
 }: CommentInputBoxProps) => {
   const [commentValue, setCommentValue] = useState('');
 
@@ -23,11 +27,11 @@ const CommentInputBox = ({
       <Box p="1rem" bgColor="white" borderRadius="1rem" boxShadow="default">
         <Flex>
           <Box>
-            <Avatar src="https://bit.ly/dan-abramov" loading="lazy" />
+            <Avatar src={userAvatar} loading="lazy" />
           </Box>
           <Flex align="center" ml="1rem">
             <Box fontSize="sm" fontWeight={600}>
-              사용자 닉네임
+              {userNickname ? userNickname : '로그인 후 이용해 주세요.'}
             </Box>
           </Flex>
         </Flex>

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -15,8 +15,6 @@ const CommentsList = ({
   handleDeleteCommentBtnClick,
   handleModifyCommentBtnClick,
 }: commentsListProps) => {
-  const isWrittenUser = true;
-
   return (
     <Box mt="1.5rem">
       <Box fontSize="lg" fontWeight={700}>
@@ -29,10 +27,12 @@ const CommentsList = ({
             contents,
             bookGroupId: _bookGroupId,
             parentCommentId: _parentCommentId,
-            userId,
+            userId: _userId,
             userProfileImage,
             createdAt: _createdAt,
             modifiedAt: _modifiedAt,
+            nickname,
+            writtenByCurrentUser,
           }) => {
             return (
               <Box
@@ -52,11 +52,11 @@ const CommentsList = ({
                       ml="1rem"
                       fontWeight={600}
                     >
-                      {userId}
+                      {nickname}
                     </Flex>
                   </Flex>
                   <Flex align="center" pt="0.4rem">
-                    {isWrittenUser ? (
+                    {writtenByCurrentUser ? (
                       <>
                         <CommentModifyModal
                           comment={contents}

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -18,14 +18,15 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   const meetingInfoQuery = useMeetingInfoQuery({ bookGroupId });
   const meetingCommentsQuery = useMeetingCommentsQuery({ bookGroupId });
   const userProfile = useMyProfileQuery();
-  const userNickname = userProfile.data?.nickname;
-  const userAvatar = userProfile.data?.profileImage;
 
   const isSuccess =
     meetingInfoQuery.isSuccess &&
     meetingCommentsQuery.isSuccess &&
     userProfile.isSuccess;
   if (!isSuccess) return null;
+
+  const userNickname = userProfile.data.nickname;
+  const userAvatar = userProfile.data.profileImage;
 
   const handleParticipateBtnClick = async () => {
     try {

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -28,14 +28,21 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       console.error(error);
     }
     meetingInfoQuery.refetch();
+    /*모임 참여 버튼 클릭시, 
+      TODO
+      2) 유저의 책장에 책 꽂기 API 호출 예정 
+      */
   };
 
-  const handleCreateCommentBtnClick = () => {
-    console.log('댓글을 생성했습니다.');
-    /*댓글 작성하기 버튼 클릭시,
-      1) 댓글 생성 API 호출 예정
-      2) 댓글 리스트 API 재호출 예정
-      3) commentsListData update*/
+  const handleCreateCommentBtnClick = async (comment: string) => {
+    if (comment.trim() === '') return;
+    try {
+      await MeetingAPI.createMeetingComment({ bookGroupId, comment });
+    } catch (error) {
+      console.error(error);
+    }
+    meetingInfoQuery.refetch();
+    meetingCommentsQuery.refetch();
   };
 
   const handleModifyCommentBtnClick = (modifiedComment: string) => {

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -7,6 +7,7 @@ import CommentInputBox from '@/ui/MeetingDetail/CommentInputBox';
 import CommentsList from '@/ui/MeetingDetail/CommentsList';
 import useMeetingInfoQuery from '@/queries/meeting/useMeetingInfoQuery';
 import useMeetingCommentsQuery from '@/queries/meeting/useMeetingCommentsQuery';
+import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
 import MeetingAPI from '@/apis/Meeting';
 
 interface MeetingDetailProps {
@@ -16,9 +17,14 @@ interface MeetingDetailProps {
 const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   const meetingInfoQuery = useMeetingInfoQuery({ bookGroupId });
   const meetingCommentsQuery = useMeetingCommentsQuery({ bookGroupId });
+  const userProfile = useMyProfileQuery();
+  const userNickname = userProfile.data?.nickname;
+  const userAvatar = userProfile.data?.profileImage;
 
   const isSuccess =
-    meetingInfoQuery.isSuccess && meetingCommentsQuery.isSuccess;
+    meetingInfoQuery.isSuccess &&
+    meetingCommentsQuery.isSuccess &&
+    userProfile.isSuccess;
   if (!isSuccess) return null;
 
   const handleParticipateBtnClick = async () => {
@@ -69,6 +75,8 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
         handleParticipateBtnClick={handleParticipateBtnClick}
       />
       <CommentInputBox
+        userNickname={userNickname}
+        userAvatar={userAvatar}
         isPartInUser={meetingInfoQuery.data.isGroupMember}
         handleCreateCommentBtnClick={handleCreateCommentBtnClick}
       />


### PR DESCRIPTION
# 구현 내용

- 모임 상세 페이지 댓글 생성 API 연동
- 모임 상세 페이지 댓글정보에 nickname추가
- 현재 로그인한 유저가 참여한 모임에서 해당 유저가 작성한 댓글의 경우 수정/삭제 버튼 노출

# 스크린샷

<img width="478" alt="스크린샷 2023-03-08 오후 6 02 05" src="https://user-images.githubusercontent.com/113018070/223669370-a720c7b6-5190-4a92-8fc9-e25f1663b897.png">

# pr 포인트


# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #138 
