### PR TITLE
[#142] 모임 상세 페이지 모임장 모임 수정 및 삭제 버튼

### DIFF
--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -23,7 +23,7 @@ const MeetingInfo = ({
     commentCount,
     owner: _owner,
     book,
-    isOwner: _isOwner,
+    isOwner,
     isGroupMember,
   } = meetingInfoData;
 
@@ -95,28 +95,58 @@ const MeetingInfo = ({
         </Flex>
       </Flex>
       <Box mt="1.5rem">
-        <Button
-          w="100%"
-          h="3.5rem"
-          fontSize="sm"
-          fontWeight="500"
-          borderRadius="2rem"
-          color="white.900"
-          border="0.1rem solid"
-          backgroundColor="main"
-          onClick={() => {
-            handleParticipateBtnClick();
-          }}
-          isDisabled={isGroupMember}
-          _disabled={{
-            border: 'none',
-            color: 'main',
-            background: 'white',
-            pointerEvents: 'none',
-          }}
-        >
-          {isGroupMember ? '참여 중' : '모임 참여하기'}
-        </Button>
+        {isOwner ? (
+          <>
+            <Button
+              w="50%"
+              h="3.5rem"
+              fontSize="sm"
+              fontWeight="500"
+              borderRadius="2rem"
+              color="white.900"
+              border="0.1rem solid"
+              backgroundColor="main"
+            >
+              모임 수정하기
+            </Button>
+            <Button
+              w="50%"
+              h="3.5rem"
+              fontSize="sm"
+              fontWeight="500"
+              borderRadius="2rem"
+              color="white.900"
+              border="0.1rem solid"
+              borderColor="main"
+              backgroundColor="white.900"
+            >
+              모임 삭제하기
+            </Button>
+          </>
+        ) : (
+          <Button
+            w="100%"
+            h="3.5rem"
+            fontSize="sm"
+            fontWeight="500"
+            borderRadius="2rem"
+            color="white.900"
+            border="0.1rem solid"
+            backgroundColor="main"
+            onClick={() => {
+              handleParticipateBtnClick();
+            }}
+            isDisabled={isGroupMember}
+            _disabled={{
+              border: 'none',
+              color: 'main',
+              background: 'white',
+              pointerEvents: 'none',
+            }}
+          >
+            {isGroupMember ? '참여 중' : '모임 참여하기'}
+          </Button>
+        )}
       </Box>
     </>
   );

--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Image, Text, Button } from '@chakra-ui/react';
 import { APIMeetingDetail } from '@/types/meetingDetail';
+import { useRouter } from 'next/navigation';
 
 interface MeetingInfoProps {
   meetingInfoData: APIMeetingDetail;
@@ -10,6 +11,10 @@ const MeetingInfo = ({
   meetingInfoData,
   handleParticipateBtnClick,
 }: MeetingInfoProps) => {
+  /* TODO 모임 수정하기 버튼 클릭시 해당 모임 수정 페이지로 bookGroupId를 통해 이동할 예정 
+   (현재 모임 수정 페이지 완성 전으로 모임 리스트 페이지로 router 연결해 놓은 상태입니다.) */
+  const router = useRouter();
+
   const {
     bookGroupId: _bookGroupId,
     title,
@@ -96,33 +101,35 @@ const MeetingInfo = ({
       </Flex>
       <Box mt="1.5rem">
         {isOwner ? (
-          <>
+          <Flex justify="space-around">
             <Button
-              w="50%"
+              w="48%"
               h="3.5rem"
               fontSize="sm"
               fontWeight="500"
               borderRadius="2rem"
-              color="white.900"
+              color="main"
               border="0.1rem solid"
-              backgroundColor="main"
+              backgroundColor="white.900"
+              onClick={() => {
+                router.push(`/meeting`);
+              }}
             >
               모임 수정하기
             </Button>
             <Button
-              w="50%"
+              w="48%"
               h="3.5rem"
               fontSize="sm"
               fontWeight="500"
               borderRadius="2rem"
-              color="white.900"
+              color="red.900"
               border="0.1rem solid"
-              borderColor="main"
               backgroundColor="white.900"
             >
               모임 삭제하기
             </Button>
-          </>
+          </Flex>
         ) : (
           <Button
             w="100%"

--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -5,11 +5,13 @@ import { useRouter } from 'next/navigation';
 interface MeetingInfoProps {
   meetingInfoData: APIMeetingDetail;
   handleParticipateBtnClick: () => void;
+  handleDeleteMeetingBtnClick: () => void;
 }
 
 const MeetingInfo = ({
   meetingInfoData,
   handleParticipateBtnClick,
+  handleDeleteMeetingBtnClick,
 }: MeetingInfoProps) => {
   /* TODO 모임 수정하기 버튼 클릭시 해당 모임 수정 페이지로 bookGroupId를 통해 이동할 예정 
    (현재 모임 수정 페이지 완성 전으로 모임 리스트 페이지로 router 연결해 놓은 상태입니다.) */
@@ -33,6 +35,18 @@ const MeetingInfo = ({
   } = meetingInfoData;
 
   const message = hasJoinPasswd ? '가입 승인 필요' : '참여 가능';
+
+  const handleMeetingDeleteButton = () => {
+    /*TODO 모임원이 1명 초과인 상태에서는 삭제가 불가능하다는 알림 메세지 UI 구현 필요*/
+    if (currentMemberCount > 1) {
+      alert('혼자가 아니면 다른 모임원들이 있어 모임 삭제가 불가능해요!');
+      return;
+    }
+
+    /*TODO 모임원이 모임장 1명인 상태에서 삭제할 때 한 번 더 확인하는 모달or바텀시트 필요
+    TODO 모임 삭제 API 연동예정*/
+    handleDeleteMeetingBtnClick();
+  };
 
   return (
     <>
@@ -126,6 +140,7 @@ const MeetingInfo = ({
               color="red.900"
               border="0.1rem solid"
               backgroundColor="white.900"
+              onClick={handleMeetingDeleteButton}
             >
               모임 삭제하기
             </Button>

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -69,11 +69,20 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       3) commentsListData update*/
   };
 
+  const handleDeleteMeetingBtnClick = () => {
+    console.log('모임이 삭제되었습니다.');
+    /*모임 삭제 버튼 클릭시,
+      1) 모임 삭제 API 호출
+      2) 모임 목록 페이지 API 호출
+      3) router로 모임 목록 페이지로 이동*/
+  };
+
   return (
     <Flex px="5%" direction="column" justify="center" mt="1rem">
       <MeetingInfo
         meetingInfoData={meetingInfoQuery.data}
         handleParticipateBtnClick={handleParticipateBtnClick}
+        handleDeleteMeetingBtnClick={handleDeleteMeetingBtnClick}
       />
       <CommentInputBox
         userNickname={userNickname}


### PR DESCRIPTION
# 구현 내용

- 모임 상세 보기 페이지에서 모임장인 user는 모임 수정하기 버튼 노출
- 모임 상세 보기 페이지에서 모임장인 user는 모임 삭제하기 버튼 노출
- 모임 수정하기 버튼 클릭시 -> 모임 리스트 페이지로 router push (모임 수정하기 페이지 완성시 수정 예정)
- 모임 삭제하기 버튼은 API 연결하기 전입니다.

# 스크린샷
![스크린샷 2023-03-09 오전 2 24 44](https://user-images.githubusercontent.com/113018070/223785315-88a7cd1d-f49b-4ed5-913a-da330c258e26.png)

# pr 포인트

# Help

- 현재 모달, toast, bottomSheet이 필요한 기능과 관련하여 어떤 것을 적용할지 정확하게 결정하지 않아 우선 기능을 위주로 구현했습니다.
- 모임 삭제가 불가능한 경우(ex 모임원이 1명 초과인 경우) 알림 메세지 UI 필요
- 모임 삭제하기의 경우에는 다시 한 번 재확인하는 기능이 필요
- 모임이 삭제된 경우 삭제가 완료되었다는 UI필요
- 이 세 가지 경우가 필요할 것 같습니다.(우선 기본 기능 구현과 API 연결부터 완료하겠습니다~)

# 관련 이슈

- Close #142 
