### PR TITLE
[#147] 모임 삭제 API 연동, 모임 상세 페이지 댓글이 없는 경우 안내 텍스트 추가

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -47,9 +47,7 @@ const MeetingAPI = {
     bookGroupId: APIMeetingGroup['bookGroupId'];
   }) =>
     publicApi.post(`/api/book-groups/${bookGroupId}/join`, {
-      data: {
-        joinPassword: null,
-      },
+      joinPassword: null,
     }),
   createMeetingComment: ({
     bookGroupId,
@@ -61,6 +59,11 @@ const MeetingAPI = {
     publicApi.post(`/api/book-groups/${bookGroupId}/comment`, {
       comment,
     }),
+  deleteMeeting: ({
+    bookGroupId,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+  }) => publicApi.delete(`/api/book-groups/${bookGroupId}`),
 };
 
 export default MeetingAPI;

--- a/src/apis/core/axios.ts
+++ b/src/apis/core/axios.ts
@@ -13,7 +13,7 @@ const setInterceptor = (instance: AxiosInstance) => {
         }
       }
 
-      if (config.method === 'get') {
+      if (config.method === 'get' || config.method === 'delete') {
         config.data = {};
       }
 

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -1,21 +1,27 @@
-import { Avatar, Box, Flex } from '@chakra-ui/react';
+import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
 
 import CommentDeleteModal from '../CommentDeleteModal';
 import CommentModifyModal from '../CommentModifyModal';
 import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
 
 interface commentsListProps {
+  isEmpty: boolean;
   commentsListData: APIBookGroupComments[];
   handleDeleteCommentBtnClick: () => void;
   handleModifyCommentBtnClick: (modifiedComment: string) => void;
 }
 
 const CommentsList = ({
+  isEmpty,
   commentsListData,
   handleDeleteCommentBtnClick,
   handleModifyCommentBtnClick,
 }: commentsListProps) => {
-  return (
+  return isEmpty ? (
+    <Text w="100%" textAlign="center" mt="4rem" fontSize="md" color="black.700">
+      첫 번째 글 작성의 주인공이 되어주세요.
+    </Text>
+  ) : (
     <Box mt="1.5rem">
       <Box fontSize="lg" fontWeight={700}>
         댓글

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Flex } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
 
 import MeetingInfo from '@/ui/MeetingDetail/MeetingInfo';
 import CommentInputBox from '@/ui/MeetingDetail/CommentInputBox';
@@ -18,6 +19,7 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   const meetingInfoQuery = useMeetingInfoQuery({ bookGroupId });
   const meetingCommentsQuery = useMeetingCommentsQuery({ bookGroupId });
   const userProfile = useMyProfileQuery();
+  const router = useRouter();
 
   const isSuccess =
     meetingInfoQuery.isSuccess &&
@@ -69,12 +71,14 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       3) commentsListData update*/
   };
 
-  const handleDeleteMeetingBtnClick = () => {
-    console.log('모임이 삭제되었습니다.');
-    /*모임 삭제 버튼 클릭시,
-      1) 모임 삭제 API 호출
-      2) 모임 목록 페이지 API 호출
-      3) router로 모임 목록 페이지로 이동*/
+  const handleDeleteMeetingBtnClick = async () => {
+    try {
+      await MeetingAPI.deleteMeeting({ bookGroupId });
+    } catch (error) {
+      console.error(error);
+    }
+
+    router.push('/meeting');
   };
 
   return (

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -81,6 +81,9 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
     router.push('/meeting');
   };
 
+  const { isGroupMember } = meetingInfoQuery.data;
+  const { bookGroupComments, isEmpty } = meetingCommentsQuery.data;
+
   return (
     <Flex px="5%" direction="column" justify="center" mt="1rem">
       <MeetingInfo
@@ -91,11 +94,12 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       <CommentInputBox
         userNickname={userNickname}
         userAvatar={userAvatar}
-        isPartInUser={meetingInfoQuery.data.isGroupMember}
+        isPartInUser={isGroupMember}
         handleCreateCommentBtnClick={handleCreateCommentBtnClick}
       />
       <CommentsList
-        commentsListData={meetingCommentsQuery.data.bookGroupComments}
+        isEmpty={isEmpty}
+        commentsListData={bookGroupComments}
         handleDeleteCommentBtnClick={handleDeleteCommentBtnClick}
         handleModifyCommentBtnClick={handleModifyCommentBtnClick}
       />

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -85,7 +85,7 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   const { bookGroupComments, isEmpty } = meetingCommentsQuery.data;
 
   return (
-    <Flex px="5%" direction="column" justify="center" mt="1rem">
+    <Flex direction="column" justify="center" mt="1rem">
       <MeetingInfo
         meetingInfoData={meetingInfoQuery.data}
         handleParticipateBtnClick={handleParticipateBtnClick}


### PR DESCRIPTION
# 구현 내용

- 모임의 인원이 모임장 1명인 경우 모임 삭제 API 연결
- 모임 삭제 후 모임 목록 페이지로 이동
- 모임 상세 페이지 댓글이 없는 경우 안내 메세지 추가

# 스크린샷

![스크린샷 2023-03-09 오전 4 54 44](https://user-images.githubusercontent.com/113018070/223831700-66b6c654-d040-4cc4-b67e-f7a1a2f3e490.png)


# pr 포인트


# Help


# 관련 이슈

- Close #147 
