### PR TITLE
[#173] 모임 상세 페이지 댓글 삭제 API 연동

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -6,6 +6,7 @@ import {
 import { APIMeetingDetailCommentsList } from '@/types/meetingDetailCommentsList';
 import { APIMeetingDetail } from '@/types/meetingDetail';
 import { publicApi } from '../core/axios';
+import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
 
 const MeetingAPI = {
   getEntireMeetingList: () =>
@@ -86,7 +87,16 @@ const MeetingAPI = {
     bookGroupId: APIMeetingGroup['bookGroupId'];
   }) => publicApi.delete(`/api/book-groups/${bookGroupId}`),
 
-
+  deleteComment: ({
+    bookGroupId,
+    commentId,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+    commentId: APIBookGroupComments['commentId'];
+  }) =>
+    publicApi.delete(`/api/book-groups/${bookGroupId}/comment`, {
+      data: { commentId },
+    }),
 };
 
 export default MeetingAPI;

--- a/src/apis/core/axios.ts
+++ b/src/apis/core/axios.ts
@@ -13,7 +13,10 @@ const setInterceptor = (instance: AxiosInstance) => {
         }
       }
 
-      if (config.method === 'get' || config.method === 'delete') {
+      if (
+        !config.data &&
+        (config.method === 'get' || config.method === 'delete')
+      ) {
         config.data = {};
       }
 

--- a/src/ui/MeetingDetail/CommentDeleteModal/index.tsx
+++ b/src/ui/MeetingDetail/CommentDeleteModal/index.tsx
@@ -11,10 +11,12 @@ import {
 } from '@chakra-ui/react';
 
 interface CommentDeleteModalProps {
-  handleDeleteCommentBtnClick: () => void;
+  commentId: number;
+  handleDeleteCommentBtnClick: (commentId: number) => void;
 }
 
 const CommentDeleteModal = ({
+  commentId,
   handleDeleteCommentBtnClick,
 }: CommentDeleteModalProps) => {
   const { onOpen, onClose, isOpen } = useDisclosure();
@@ -54,7 +56,7 @@ const CommentDeleteModal = ({
             <Button
               mr={3}
               onClick={() => {
-                handleDeleteCommentBtnClick();
+                handleDeleteCommentBtnClick(commentId);
                 onClose();
               }}
               bgColor="white"

--- a/src/ui/MeetingDetail/CommentModifyModal/index.tsx
+++ b/src/ui/MeetingDetail/CommentModifyModal/index.tsx
@@ -13,11 +13,13 @@ import {
 } from '@chakra-ui/react';
 
 interface CommentModifyModalProps {
+  commentId: number;
   comment: string;
   handleModifyCommentBtnClick: (modifiedComment: string) => void;
 }
 
 const CommentModifyModal = ({
+  commentId,
   comment,
   handleModifyCommentBtnClick,
 }: CommentModifyModalProps) => {
@@ -28,6 +30,8 @@ const CommentModifyModal = ({
     setModeifiedValue(event.target.value);
   };
 
+  /* 추후 commentId 사용 예정(husky) */
+  console.log(commentId);
   return (
     <>
       <Button

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -7,7 +7,7 @@ import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
 interface commentsListProps {
   isEmpty: boolean;
   commentsListData: APIBookGroupComments[];
-  handleDeleteCommentBtnClick: () => void;
+  handleDeleteCommentBtnClick: (commentId: number) => void;
   handleModifyCommentBtnClick: (modifiedComment: string) => void;
 }
 
@@ -66,11 +66,13 @@ const CommentsList = ({
                       <>
                         <CommentModifyModal
                           comment={contents}
+                          commentId={commentId}
                           handleModifyCommentBtnClick={
                             handleModifyCommentBtnClick
                           }
                         />
                         <CommentDeleteModal
+                          commentId={commentId}
                           handleDeleteCommentBtnClick={
                             handleDeleteCommentBtnClick
                           }

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -63,12 +63,15 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       3) commentsListData update*/
   };
 
-  const handleDeleteCommentBtnClick = () => {
-    console.log('댓글이 삭제되었습니다.');
-    /*댓글 삭제하기 버튼 클릭시,
-      1) 댓글 삭제 API 호출
-      2) 댓글 리스트 API 호출
-      3) commentsListData update*/
+  const handleDeleteCommentBtnClick = async (commentId: number) => {
+    console.log('commentId >>>>>>', commentId);
+    try {
+      await MeetingAPI.deleteComment({ bookGroupId, commentId });
+    } catch (error) {
+      console.error(error);
+    }
+    meetingCommentsQuery.refetch();
+    /*댓글 삭제하기 버튼 클릭시*/
   };
 
   const handleDeleteMeetingBtnClick = async () => {

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -64,7 +64,6 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   };
 
   const handleDeleteCommentBtnClick = async (commentId: number) => {
-    console.log('commentId >>>>>>', commentId);
     try {
       await MeetingAPI.deleteComment({ bookGroupId, commentId });
     } catch (error) {

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -70,7 +70,6 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
       console.error(error);
     }
     meetingCommentsQuery.refetch();
-    /*댓글 삭제하기 버튼 클릭시*/
   };
 
   const handleDeleteMeetingBtnClick = async () => {


### PR DESCRIPTION
# 구현 내용

- 모임 상세 페이지 댓글 삭제 API 연동
- 댓글 삭제 후 댓글 리스트 refetch

# 스크린샷

<!-- 없는 경우 생략한다. -->

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

불필요한 코드가 있는지 매의 눈으로 관찰 부탁드립니다 🤩

# 관련 이슈

- Close #173
