### PR TITLE
[#175] 모임 상세 페이지 댓글 수정 API 연결

### DIFF
--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -109,8 +109,7 @@ const MeetingAPI = {
     commentId: number;
     comment: string;
   }) =>
-    publicApi.patch(`/api/book-groups/${bookGroupId}/comment`, {
-      commentId,
+    publicApi.patch(`/api/book-groups/${bookGroupId}/comments/${commentId}`, {
       comment,
     }),
 };

--- a/src/apis/Meeting/index.ts
+++ b/src/apis/Meeting/index.ts
@@ -99,6 +99,20 @@ const MeetingAPI = {
     publicApi.delete(`/api/book-groups/${bookGroupId}/comments`, {
       data: { commentId },
     }),
+
+  patchMeetingComment: ({
+    bookGroupId,
+    commentId,
+    comment,
+  }: {
+    bookGroupId: APIMeetingGroup['bookGroupId'];
+    commentId: number;
+    comment: string;
+  }) =>
+    publicApi.patch(`/api/book-groups/${bookGroupId}/comment`, {
+      commentId,
+      comment,
+    }),
 };
 
 export default MeetingAPI;

--- a/src/ui/MeetingDetail/CommentModifyModal/index.tsx
+++ b/src/ui/MeetingDetail/CommentModifyModal/index.tsx
@@ -33,8 +33,6 @@ const CommentModifyModal = ({
     setModeifiedValue(event.target.value);
   };
 
-  /* 추후 commentId 사용 예정(husky) */
-  console.log(commentId);
   return (
     <>
       <Button

--- a/src/ui/MeetingDetail/CommentModifyModal/index.tsx
+++ b/src/ui/MeetingDetail/CommentModifyModal/index.tsx
@@ -15,7 +15,10 @@ import {
 interface CommentModifyModalProps {
   commentId: number;
   comment: string;
-  handleModifyCommentBtnClick: (modifiedComment: string) => void;
+  handleModifyCommentBtnClick: (
+    modifiedComment: string,
+    commentId: number
+  ) => void;
 }
 
 const CommentModifyModal = ({
@@ -63,7 +66,7 @@ const CommentModifyModal = ({
             <Button
               mr={3}
               onClick={() => {
-                handleModifyCommentBtnClick(modifiedValue);
+                handleModifyCommentBtnClick(modifiedValue, commentId);
                 onClose();
               }}
               bgColor="white"

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -8,7 +8,10 @@ interface commentsListProps {
   isEmpty: boolean;
   commentsListData: APIBookGroupComments[];
   handleDeleteCommentBtnClick: (commentId: number) => void;
-  handleModifyCommentBtnClick: (modifiedComment: string) => void;
+  handleModifyCommentBtnClick: (
+    modifiedComment: string,
+    commentId: number
+  ) => void;
 }
 
 const CommentsList = ({
@@ -65,8 +68,8 @@ const CommentsList = ({
                     {writtenByCurrentUser ? (
                       <>
                         <CommentModifyModal
-                          comment={contents}
                           commentId={commentId}
+                          comment={contents}
                           handleModifyCommentBtnClick={
                             handleModifyCommentBtnClick
                           }

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -50,9 +50,20 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
     meetingCommentsQuery.refetch();
   };
 
-  const handleModifyCommentBtnClick = (modifiedComment: string) => {
-    console.log('댓글이 수정되었습니다.');
-    console.log(modifiedComment);
+  const handleModifyCommentBtnClick = async (
+    modifiedComment: string,
+    commentId: number
+  ) => {
+    try {
+      await MeetingAPI.patchMeetingComment({
+        bookGroupId,
+        commentId,
+        comment: modifiedComment,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+    meetingCommentsQuery.refetch();
   };
 
   const handleDeleteCommentBtnClick = async (commentId: number) => {


### PR DESCRIPTION
# 구현 내용

- 모임 상세 페이지 댓글 수정 API 연결

# 스크린샷

# pr 포인트

# Help

- 모임 상세 페이지 댓글 삭제 관련해서 URL주소가 조금 바뀌어서 그 부분까지 수정에 넣었습니다.
- comment를 -> comments로 변경

- 이번에는 console.log를 검색해서 찾아내서 지워보았습니다. 혹시나 모를 불필요한 코드가 있다면 매의 눈으로 관찰 부탁드려용~


# 관련 이슈

- Close #175 
