### PR TITLE
[#212] 조건에 따른 댓글 노출 제한과 안내 텍스트 작성, 모임 참여버튼 클릭시 조건에 따른 바텀시트 노출

### DIFF
--- a/src/apis/meeting/index.ts
+++ b/src/apis/meeting/index.ts
@@ -12,7 +12,7 @@ const MeetingAPI = {
   getEntireMeetingList: () =>
     publicApi.get<APIEntireMeetingList>(`/service-api/book-groups`, {
       params: {
-        pageSize: 10,
+        pageSize: 100,
         sortDirection: 'DESC',
       },
     }),
@@ -36,7 +36,7 @@ const MeetingAPI = {
       `/service-api/book-groups/${bookGroupId}/comments`,
       {
         params: {
-          pageSize: 10,
+          pageSize: 100,
           sortDirection: 'DESC',
         },
       }

--- a/src/constants/initialBookGroupComments.ts
+++ b/src/constants/initialBookGroupComments.ts
@@ -1,4 +1,4 @@
-export const COMMENTS_DUMMY_DATA = [
+export const initialBookGroupComments = [
   {
     commentId: 11414,
     contents:

--- a/src/ui/Meeting/MeetingList/MeetingListItem.tsx
+++ b/src/ui/Meeting/MeetingList/MeetingListItem.tsx
@@ -5,8 +5,9 @@ import Link from 'next/link';
 const MeetingListItem = ({
   bookGroupId,
   title,
+  isPublic,
   introduce,
-  hasJoinPasswd,
+  hasJoinPasswd: _hasJoinPasswd,
   startDate,
   endDate,
   maxMemberCount,
@@ -36,7 +37,7 @@ const MeetingListItem = ({
               {startDate} ~ {endDate}
             </Text>
             <Box>
-              {hasJoinPasswd ? (
+              {!isPublic ? (
                 <Image src="/icons/lock.svg" alt="잠김" w="1.7rem" />
               ) : (
                 <Image src="/icons/unlock.svg" alt="풀림" w="1.7rem" />

--- a/src/ui/Meeting/index.tsx
+++ b/src/ui/Meeting/index.tsx
@@ -21,7 +21,6 @@ const MeetingPageContainer = () => {
   const { isSuccess, data } = useEntireMeetingListQuery();
 
   const handleSumbit = () => {
-    console.log(searchValue);
     const { input } = searchValue;
     if (input.trim().length === 0) {
       /*공백만 입력한 경우 전체 데이터 렌더링 */

--- a/src/ui/MeetingDetail/CommentInputBox/index.tsx
+++ b/src/ui/MeetingDetail/CommentInputBox/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Textarea, Button, Avatar } from '@chakra-ui/react';
+import { Box, Flex, Textarea, Button } from '@chakra-ui/react';
 import { useState } from 'react';
 interface CommentInputBoxProps {
   isPartInUser: boolean;
@@ -10,8 +10,6 @@ interface CommentInputBoxProps {
 const CommentInputBox = ({
   isPartInUser,
   handleCreateCommentBtnClick,
-  userNickname,
-  userAvatar,
 }: CommentInputBoxProps) => {
   const [commentValue, setCommentValue] = useState('');
 
@@ -25,16 +23,6 @@ const CommentInputBox = ({
         댓글 작성
       </Box>
       <Box p="1rem" bgColor="white" borderRadius="1rem" boxShadow="default">
-        <Flex>
-          <Box>
-            <Avatar src={userAvatar} loading="lazy" />
-          </Box>
-          <Flex align="center" ml="1rem">
-            <Box fontSize="sm" fontWeight={600}>
-              {userNickname ? userNickname : '로그인 후 이용해 주세요.'}
-            </Box>
-          </Flex>
-        </Flex>
         <Box m="1rem 0">
           <Textarea
             bgColor="white.800"

--- a/src/ui/MeetingDetail/CommentsList/GuideMessage.tsx
+++ b/src/ui/MeetingDetail/CommentsList/GuideMessage.tsx
@@ -1,0 +1,74 @@
+import { VStack, Text, Highlight, Link, Image, Box } from '@chakra-ui/react';
+
+import Button from '@/ui/common/Button';
+
+interface GuideMessageProps {
+  isAuthed: boolean;
+  isPublic: boolean;
+  isGroupMember: boolean;
+}
+
+const GuideMessage = ({
+  isAuthed,
+  isPublic,
+  isGroupMember,
+}: GuideMessageProps) => {
+  const kakaoUrl = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
+
+  return (
+    <Box>
+      <Box>
+        {!isAuthed && !isPublic ? (
+          <VStack h="20rem" direction="column" gap="1rem">
+            <Text
+              w="100%"
+              textAlign="center"
+              mt="4rem"
+              fontSize="lg"
+              color="black.700"
+            >
+              <Highlight query="로그인" styles={{ color: 'main' }}>
+                로그인 후 이용해 주세요
+              </Highlight>
+            </Text>
+            <Link href={kakaoUrl} style={{ width: '100%' }}>
+              <Button scheme="kakao" fullWidth>
+                <Image
+                  src="/images/kakao.svg"
+                  alt="카카오 로고"
+                  width={21}
+                  height={19}
+                />
+                카카오 로그인
+              </Button>
+            </Link>
+          </VStack>
+        ) : (
+          ''
+        )}
+      </Box>
+      <Box>
+        {isAuthed && !isPublic && !isGroupMember ? (
+          <Text
+            h="10rem"
+            w="100%"
+            textAlign="center"
+            mt="4rem"
+            fontSize="lg"
+            color="black.700"
+          >
+            <Highlight query="모임에 참여한 사람" styles={{ color: 'main' }}>
+              이 모임은 모임에 참여한 사람만
+            </Highlight>
+            <br />
+            글을 볼 수 있어요
+          </Text>
+        ) : (
+          ''
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default GuideMessage;

--- a/src/ui/MeetingDetail/CommentsList/commentsDummy.tsx
+++ b/src/ui/MeetingDetail/CommentsList/commentsDummy.tsx
@@ -1,0 +1,34 @@
+export const COMMENTS_DUMMY_DATA = [
+  {
+    commentId: 11414,
+    contents:
+      '다독 서비스 개발자 백민종님은 누구보다 열정적이고 훌륭한 개발자입니다. 리더십이 뛰어납니다. 그리고 내기를 좋아합니다. 도박을 좋아하는 것은 아니고 콜라, 커피내기를 주로 합니다. 승률은 낮습니다.',
+    userProfileImage: '',
+    nickname: '고양시MZ',
+    writtenByCurrentUser: false,
+  },
+  {
+    commentId: 53452,
+    contents:
+      '다독 서비스 개발자 우대현님은 착하고 성실하고 성숙하고 센스있고 어른스럽습니다. 죄송합니다. 제가 이 부분을 만들었기 때문에 제가 상상하는 미래의 제 모습을 적어 보았습니다.',
+    userProfileImage: '',
+    nickname: 'OLDBOY',
+    writtenByCurrentUser: false,
+  },
+  {
+    commentId: 36363,
+    contents:
+      '다독 서비스 개발자 김규란님은 근면성실은 아니지만 정말 열심히 공부하고 개발하는 개발자 입니다. 운동신경이 뛰어납니다. 저희 팀 내에서 운동 관련 승률이 가장 높습니다. 이기고 싶다면 규란님과 팀을 해야 합니다.',
+    userProfileImage: '',
+    nickname: 'fired계란',
+    writtenByCurrentUser: false,
+  },
+  {
+    commentId: 67951,
+    contents:
+      '다독 서비스 개발자 김재현님은 의외성 No.1 입니다. 맡은 일을 뚝딱뚝딱 잘해내 팀원들을 놀라게 하는것이 특기입니다. 또한 프로젝트 기간 동안 데브코스 강의장과 가장 가까이 지내면서 여유를 부리다 늦게와 구론산을 많이 샀습니다.(늦게 오는것은 아니고 항상 1-3분 정도? ㅎ)',
+    userProfileImage: '',
+    nickname: 'OneMetro',
+    writtenByCurrentUser: false,
+  },
+];

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -1,20 +1,11 @@
-import {
-  Avatar,
-  Box,
-  Flex,
-  Highlight,
-  Text,
-  VStack,
-  Link,
-  Image,
-} from '@chakra-ui/react';
+import { Avatar, Box, Flex, Highlight, Text } from '@chakra-ui/react';
 
-import Button from '@/ui/common/Button';
 import { useAuth } from '@/hooks/auth';
 import CommentDeleteModal from '../CommentDeleteModal';
 import CommentModifyModal from '../CommentModifyModal';
 import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
 import { COMMENTS_DUMMY_DATA } from './commentsDummy';
+import GuideMessage from './GuideMessage';
 
 interface commentsListProps {
   isGroupMember: boolean;
@@ -39,65 +30,26 @@ const CommentsList = ({
   const { isAuthed } = useAuth();
 
   const getFilteredComments = () => {
-    if (!isAuthed && !isPublic) {
+    console.log(isPublic);
+    console.log(commentsListData);
+    const commentsLength = commentsListData.length;
+
+    if (!isAuthed && !isPublic && commentsLength < 5) {
+      console.log('slice');
+      return COMMENTS_DUMMY_DATA.slice(0, commentsLength);
+    } else if (!isAuthed && !isPublic) {
       return COMMENTS_DUMMY_DATA;
+    }
+
+    if (isAuthed && !isPublic && !isGroupMember && commentsLength < 5) {
+      return COMMENTS_DUMMY_DATA.slice(0, commentsLength);
     } else if (isAuthed && !isPublic && !isGroupMember) {
       return COMMENTS_DUMMY_DATA;
     }
     return commentsListData;
   };
 
-  const getGuide = () => {
-    if (!isAuthed && !isPublic) {
-      const kakaoUrl = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
-      return (
-        <VStack h="20rem" direction="column" gap="1rem">
-          <Text
-            w="100%"
-            textAlign="center"
-            mt="4rem"
-            fontSize="lg"
-            color="black.700"
-          >
-            <Highlight query="로그인" styles={{ color: 'main' }}>
-              로그인 후 이용해 주세요
-            </Highlight>
-          </Text>
-          <Link href={kakaoUrl} style={{ width: '100%' }}>
-            <Button scheme="kakao" fullWidth>
-              <Image
-                src="/images/kakao.svg"
-                alt="카카오 로고"
-                width={21}
-                height={19}
-              />
-              카카오 로그인
-            </Button>
-          </Link>
-        </VStack>
-      );
-    } else if (isAuthed && !isPublic && !isGroupMember) {
-      return (
-        <Text
-          h="10rem"
-          w="100%"
-          textAlign="center"
-          mt="4rem"
-          fontSize="lg"
-          color="black.700"
-        >
-          <Highlight query="모임에 참여한 사람" styles={{ color: 'main' }}>
-            이 모임은 모임에 참여한 사람만
-          </Highlight>
-          <br />
-          글을 볼 수 있어요
-        </Text>
-      );
-    }
-  };
-
   const filteredComments = getFilteredComments();
-  const guide = getGuide();
 
   return isEmpty ? (
     <Text w="100%" textAlign="center" mt="4rem" fontSize="lg" color="black.700">
@@ -178,7 +130,11 @@ const CommentsList = ({
             }
           )}
       </Box>
-      {guide}
+      <GuideMessage
+        isAuthed={isAuthed}
+        isPublic={isPublic}
+        isGroupMember={isGroupMember}
+      />
     </Box>
   );
 };

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -1,10 +1,24 @@
-import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
+import {
+  Avatar,
+  Box,
+  Flex,
+  Highlight,
+  Text,
+  VStack,
+  Link,
+  Image,
+} from '@chakra-ui/react';
 
+import Button from '@/ui/common/Button';
+import { useAuth } from '@/hooks/auth';
 import CommentDeleteModal from '../CommentDeleteModal';
 import CommentModifyModal from '../CommentModifyModal';
 import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
+import { COMMENTS_DUMMY_DATA } from './commentsDummy';
 
 interface commentsListProps {
+  isGroupMember: boolean;
+  isPublic: boolean;
   isEmpty: boolean;
   commentsListData: APIBookGroupComments[];
   handleDeleteCommentBtnClick: (commentId: number) => void;
@@ -15,14 +29,81 @@ interface commentsListProps {
 }
 
 const CommentsList = ({
+  isGroupMember,
+  isPublic,
   isEmpty,
   commentsListData,
   handleDeleteCommentBtnClick,
   handleModifyCommentBtnClick,
 }: commentsListProps) => {
+  const { isAuthed } = useAuth();
+
+  const getFilteredComments = () => {
+    if (!isAuthed && !isPublic) {
+      return COMMENTS_DUMMY_DATA;
+    } else if (isAuthed && !isPublic && !isGroupMember) {
+      return COMMENTS_DUMMY_DATA;
+    }
+    return commentsListData;
+  };
+
+  const getGuide = () => {
+    if (!isAuthed && !isPublic) {
+      const kakaoUrl = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
+      return (
+        <VStack h="20rem" direction="column" gap="1rem">
+          <Text
+            w="100%"
+            textAlign="center"
+            mt="4rem"
+            fontSize="lg"
+            color="black.700"
+          >
+            <Highlight query="로그인" styles={{ color: 'main' }}>
+              로그인 후 이용해 주세요
+            </Highlight>
+          </Text>
+          <Link href={kakaoUrl} style={{ width: '100%' }}>
+            <Button scheme="kakao" fullWidth>
+              <Image
+                src="/images/kakao.svg"
+                alt="카카오 로고"
+                width={21}
+                height={19}
+              />
+              카카오 로그인
+            </Button>
+          </Link>
+        </VStack>
+      );
+    } else if (isAuthed && !isPublic && !isGroupMember) {
+      return (
+        <Text
+          h="10rem"
+          w="100%"
+          textAlign="center"
+          mt="4rem"
+          fontSize="lg"
+          color="black.700"
+        >
+          <Highlight query="모임에 참여한 사람" styles={{ color: 'main' }}>
+            이 모임은 모임에 참여한 사람만
+          </Highlight>
+          <br />
+          글을 볼 수 있어요
+        </Text>
+      );
+    }
+  };
+
+  const filteredComments = getFilteredComments();
+  const guide = getGuide();
+
   return isEmpty ? (
     <Text w="100%" textAlign="center" mt="4rem" fontSize="lg" color="black.700">
-      첫 번째 글 작성의 주인공이 되어주세요.
+      <Highlight query="주인공" styles={{ color: 'main' }}>
+        첫 번째 글 작성의 주인공이 되어주세요.
+      </Highlight>
     </Text>
   ) : (
     <Box mt="1.5rem">
@@ -30,70 +111,74 @@ const CommentsList = ({
         댓글
       </Box>
       <Box>
-        {commentsListData.map(
-          ({
-            commentId,
-            contents,
-            bookGroupId: _bookGroupId,
-            parentCommentId: _parentCommentId,
-            userId: _userId,
-            userProfileImage,
-            createdAt: _createdAt,
-            modifiedAt: _modifiedAt,
-            nickname,
-            writtenByCurrentUser,
-          }) => {
-            return (
-              <Box
-                key={commentId}
-                mt="1rem"
-                p="1rem"
-                bgColor="white"
-                borderRadius="1.5rem"
-                boxShadow="default"
-              >
-                <Flex mb="0.5rem" justify="space-between">
-                  <Flex>
-                    <Avatar src={userProfileImage} loading="lazy" />
-                    <Flex
-                      align="center"
-                      fontSize="sm"
-                      ml="1rem"
-                      fontWeight={600}
-                    >
-                      {nickname}
+        {filteredComments &&
+          filteredComments.map(
+            ({
+              commentId,
+              contents,
+              userProfileImage,
+              nickname,
+              writtenByCurrentUser,
+            }) => {
+              return (
+                <Box
+                  filter="auto"
+                  blur={
+                    (!isAuthed && !isPublic) ||
+                    (isAuthed && !isPublic && !isGroupMember)
+                      ? '3px'
+                      : ''
+                  }
+                  key={commentId}
+                  mt="1rem"
+                  p="1rem"
+                  bgColor="white"
+                  borderRadius="1.5rem"
+                  boxShadow="default"
+                >
+                  <Flex mb="0.5rem" justify="space-between">
+                    <Flex>
+                      <Avatar src={userProfileImage} loading="lazy" />
+                      <Flex
+                        align="center"
+                        fontSize="sm"
+                        ml="1rem"
+                        fontWeight={500}
+                      >
+                        {nickname}
+                      </Flex>
+                    </Flex>
+                    <Flex align="center" pt="0.4rem">
+                      {writtenByCurrentUser ? (
+                        <>
+                          <CommentModifyModal
+                            commentId={commentId}
+                            comment={contents}
+                            handleModifyCommentBtnClick={
+                              handleModifyCommentBtnClick
+                            }
+                          />
+                          <CommentDeleteModal
+                            commentId={commentId}
+                            handleDeleteCommentBtnClick={
+                              handleDeleteCommentBtnClick
+                            }
+                          />
+                        </>
+                      ) : (
+                        ''
+                      )}
                     </Flex>
                   </Flex>
-                  <Flex align="center" pt="0.4rem">
-                    {writtenByCurrentUser ? (
-                      <>
-                        <CommentModifyModal
-                          commentId={commentId}
-                          comment={contents}
-                          handleModifyCommentBtnClick={
-                            handleModifyCommentBtnClick
-                          }
-                        />
-                        <CommentDeleteModal
-                          commentId={commentId}
-                          handleDeleteCommentBtnClick={
-                            handleDeleteCommentBtnClick
-                          }
-                        />
-                      </>
-                    ) : (
-                      ''
-                    )}
-                  </Flex>
-                </Flex>
-                <Box lineHeight="2.2rem" fontSize="md">
-                  {contents}
+                  <Box lineHeight="2.2rem" fontSize="md">
+                    {contents}
+                  </Box>
                 </Box>
-              </Box>
-            );
-          }
-        )}
+              );
+            }
+          )}
       </Box>
+      {guide}
     </Box>
   );
 };

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/hooks/auth';
 import CommentDeleteModal from '../CommentDeleteModal';
 import CommentModifyModal from '../CommentModifyModal';
 import { APIBookGroupComments } from '@/types/meetingDetailCommentsList';
-import { COMMENTS_DUMMY_DATA } from './commentsDummy';
+import { initialBookGroupComments } from '@/constants/initialBookGroupComments';
 import GuideMessage from './GuideMessage';
 
 interface commentsListProps {
@@ -36,15 +36,15 @@ const CommentsList = ({
 
     if (!isAuthed && !isPublic && commentsLength < 5) {
       console.log('slice');
-      return COMMENTS_DUMMY_DATA.slice(0, commentsLength);
+      return initialBookGroupComments.slice(0, commentsLength);
     } else if (!isAuthed && !isPublic) {
-      return COMMENTS_DUMMY_DATA;
+      return initialBookGroupComments;
     }
 
     if (isAuthed && !isPublic && !isGroupMember && commentsLength < 5) {
-      return COMMENTS_DUMMY_DATA.slice(0, commentsLength);
+      return initialBookGroupComments.slice(0, commentsLength);
     } else if (isAuthed && !isPublic && !isGroupMember) {
-      return COMMENTS_DUMMY_DATA;
+      return initialBookGroupComments;
     }
     return commentsListData;
   };

--- a/src/ui/MeetingDetail/CommentsList/index.tsx
+++ b/src/ui/MeetingDetail/CommentsList/index.tsx
@@ -30,12 +30,9 @@ const CommentsList = ({
   const { isAuthed } = useAuth();
 
   const getFilteredComments = () => {
-    console.log(isPublic);
-    console.log(commentsListData);
     const commentsLength = commentsListData.length;
 
     if (!isAuthed && !isPublic && commentsLength < 5) {
-      console.log('slice');
       return initialBookGroupComments.slice(0, commentsLength);
     } else if (!isAuthed && !isPublic) {
       return initialBookGroupComments;

--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -11,6 +11,8 @@ import { APIMeetingDetail } from '@/types/meetingDetail';
 import { useRouter } from 'next/router';
 import BottomSheet from '@/ui/common/BottomSheet';
 import { useState } from 'react';
+import { useAuth } from '@/hooks/auth';
+import LoginBottomSheet from '@/ui/LoginBottomSheet';
 
 interface MeetingInfoProps {
   meetingInfoData: APIMeetingDetail;
@@ -25,6 +27,7 @@ const MeetingInfo = ({
 }: MeetingInfoProps) => {
   const router = useRouter();
   const [password, setPassword] = useState('');
+  const { isAuthed } = useAuth();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const {
@@ -45,9 +48,7 @@ const MeetingInfo = ({
     isGroupMember,
   } = meetingInfoData;
 
-  const message = hasJoinPasswd
-    ? '가입시 비밀번호 입력 필요'
-    : '바로 참여 가능';
+  const message = hasJoinPasswd ? '가입 비밀번호 입력 필요' : '바로 참여 가능';
 
   const handleMeetingDeleteButton = () => {
     /*TODO 모임원이 1명 초과인 상태에서는 삭제가 불가능하다는 알림 메세지 UI 구현 필요*/
@@ -61,6 +62,14 @@ const MeetingInfo = ({
 
   const onChangePassword = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);
+  };
+
+  const onPartInButtonClick = () => {
+    if (!isAuthed) {
+      onOpen();
+      return;
+    }
+    hasJoinPasswd ? onOpen() : handleParticipateBtnClick();
   };
 
   return (
@@ -133,10 +142,10 @@ const MeetingInfo = ({
           <Flex justify="space-around">
             <Button
               w="48%"
-              h="3.5rem"
-              fontSize="sm"
-              fontWeight="500"
-              borderRadius="2rem"
+              h="4.5rem"
+              fontSize="md"
+              fontWeight="600"
+              borderRadius="1.2rem"
               color="main"
               border="0.1rem solid"
               backgroundColor="white.900"
@@ -148,10 +157,10 @@ const MeetingInfo = ({
             </Button>
             <Button
               w="48%"
-              h="3.5rem"
-              fontSize="sm"
-              fontWeight="500"
-              borderRadius="2rem"
+              h="4.5rem"
+              fontSize="md"
+              fontWeight="600"
+              borderRadius="1.2rem"
               color="red.900"
               border="0.1rem solid"
               backgroundColor="white.900"
@@ -164,16 +173,14 @@ const MeetingInfo = ({
           <>
             <Button
               w="100%"
-              h="3.5rem"
-              fontSize="sm"
-              fontWeight="500"
-              borderRadius="2rem"
+              h="4.5rem"
+              fontSize="md"
+              fontWeight="600"
+              borderRadius="1.2rem"
               color="white.900"
               border="0.1rem solid"
               backgroundColor="main"
-              onClick={() => {
-                hasJoinPasswd ? onOpen() : handleParticipateBtnClick();
-              }}
+              onClick={onPartInButtonClick}
               isDisabled={isGroupMember}
               _disabled={{
                 border: 'none',
@@ -184,7 +191,7 @@ const MeetingInfo = ({
             >
               {isGroupMember ? '참여 중' : '모임 참여하기'}
             </Button>
-            <BottomSheet isOpen={isOpen} onClose={onClose}>
+            <BottomSheet isOpen={isAuthed ? isOpen : false} onClose={onClose}>
               <Flex p="3rem" h="90vh" gap="3rem" direction="column">
                 <Button
                   alignSelf="flex-end"
@@ -222,6 +229,7 @@ const MeetingInfo = ({
           </>
         )}
       </Box>
+      <LoginBottomSheet isOpen={!isAuthed ? isOpen : false} onClose={onClose} />
     </>
   );
 };

--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -28,7 +28,16 @@ const MeetingInfo = ({
   const router = useRouter();
   const [password, setPassword] = useState('');
   const { isAuthed } = useAuth();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isLoginModalOpen,
+    onOpen: onLoginModalOpen,
+    onClose: onLoginModalClose,
+  } = useDisclosure();
+  const {
+    isOpen: isPasswordModalOpen,
+    onOpen: onPasswordModalOpen,
+    onClose: onPasswordModalClose,
+  } = useDisclosure();
 
   const {
     bookGroupId,
@@ -66,10 +75,10 @@ const MeetingInfo = ({
 
   const onPartInButtonClick = () => {
     if (!isAuthed) {
-      onOpen();
+      onLoginModalOpen();
       return;
     }
-    hasJoinPasswd ? onOpen() : handleParticipateBtnClick();
+    hasJoinPasswd ? onPasswordModalOpen() : handleParticipateBtnClick();
   };
 
   return (
@@ -191,14 +200,17 @@ const MeetingInfo = ({
             >
               {isGroupMember ? '참여 중' : '모임 참여하기'}
             </Button>
-            <BottomSheet isOpen={isAuthed ? isOpen : false} onClose={onClose}>
+            <BottomSheet
+              isOpen={isPasswordModalOpen}
+              onClose={onPasswordModalClose}
+            >
               <Flex p="3rem" h="90vh" gap="3rem" direction="column">
                 <Button
                   alignSelf="flex-end"
                   bgColor="white.900"
                   onClick={() => {
                     handleParticipateBtnClick(password);
-                    onClose();
+                    onPasswordModalClose();
                     setPassword('');
                   }}
                 >
@@ -229,7 +241,7 @@ const MeetingInfo = ({
           </>
         )}
       </Box>
-      <LoginBottomSheet isOpen={!isAuthed ? isOpen : false} onClose={onClose} />
+      <LoginBottomSheet isOpen={isLoginModalOpen} onClose={onLoginModalClose} />
     </>
   );
 };

--- a/src/ui/MeetingDetail/MeetingInfo/index.tsx
+++ b/src/ui/MeetingDetail/MeetingInfo/index.tsx
@@ -82,7 +82,7 @@ const MeetingInfo = ({
           {introduce}
         </Text>
       </Flex>
-      <Flex mt="1.5rem" justify="space-between" h="13rem">
+      <Flex mt="1.5rem" justify="space-between" h="14rem">
         <Box w="68%" bgColor="white" borderRadius="1rem" boxShadow="default">
           <Flex p="1rem" h="100%" direction="column" justify="space-between">
             <Box h="60%">

--- a/src/ui/MeetingDetail/index.tsx
+++ b/src/ui/MeetingDetail/index.tsx
@@ -6,7 +6,6 @@ import CommentInputBox from '@/ui/MeetingDetail/CommentInputBox';
 import CommentsList from '@/ui/MeetingDetail/CommentsList';
 import useMeetingInfoQuery from '@/queries/meeting/useMeetingInfoQuery';
 import useMeetingCommentsQuery from '@/queries/meeting/useMeetingCommentsQuery';
-import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
 import MeetingAPI from '@/apis/meeting';
 
 interface MeetingDetailProps {
@@ -16,17 +15,11 @@ interface MeetingDetailProps {
 const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
   const meetingInfoQuery = useMeetingInfoQuery({ bookGroupId });
   const meetingCommentsQuery = useMeetingCommentsQuery({ bookGroupId });
-  const userProfile = useMyProfileQuery();
   const router = useRouter();
 
   const isSuccess =
-    meetingInfoQuery.isSuccess &&
-    meetingCommentsQuery.isSuccess &&
-    userProfile.isSuccess;
+    meetingInfoQuery.isSuccess && meetingCommentsQuery.isSuccess;
   if (!isSuccess) return null;
-
-  const userNickname = userProfile.data.nickname;
-  const userAvatar = userProfile.data.profileImage;
 
   const handleParticipateBtnClick = async (password?: string) => {
     try {
@@ -83,7 +76,7 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
     router.push('/meeting');
   };
 
-  const { isGroupMember } = meetingInfoQuery.data;
+  const { isGroupMember, isPublic } = meetingInfoQuery.data;
   const { bookGroupComments, isEmpty } = meetingCommentsQuery.data;
 
   return (
@@ -94,12 +87,12 @@ const MeetingDetail = ({ bookGroupId }: MeetingDetailProps) => {
         handleDeleteMeetingBtnClick={handleDeleteMeetingBtnClick}
       />
       <CommentInputBox
-        userNickname={userNickname}
-        userAvatar={userAvatar}
         isPartInUser={isGroupMember}
         handleCreateCommentBtnClick={handleCreateCommentBtnClick}
       />
       <CommentsList
+        isGroupMember={isGroupMember}
+        isPublic={isPublic}
         isEmpty={isEmpty}
         commentsListData={bookGroupComments}
         handleDeleteCommentBtnClick={handleDeleteCommentBtnClick}


### PR DESCRIPTION
# 구현 내용

- 로그인 여부, 모임 가입 여부, 모임 공개 여부에 따른 댓글 노출 개수 제한
- 댓글이 아무것도 없는 경우에는 "첫 글의 주인공이 되어주세요" 텍스트 노출
- 로그인o + 비공개 + 미가입 => 더미 데이터 블러처리 노출 및 안내 텍스트 노출
- 로그인x + 비공개 => 더미 데이터 블러처리 노출 및 로그인 버튼 및 안내 텍스트 노출

- 로그인x + 모임 참여 버튼 클릭시 => 로그인 바텀 시트 노출

# 스크린샷
- 로그인x + 비공개 모임

<img width="452" alt="스크린샷 2023-03-13 오후 10 13 48" src="https://user-images.githubusercontent.com/113018070/224712147-a4788541-356e-4dee-9e8c-c8305258ba9a.png">

- 로그인o + 비공개 모임 + 모임 미가입

<img width="452" alt="스크린샷 2023-03-13 오후 10 14 36" src="https://user-images.githubusercontent.com/113018070/224712326-09194311-1682-4b09-9ca1-70f28e3429a1.png">

- 로그인x + 모임 참여버튼 클릭시 로그인 바텀 시트

<img width="452" alt="스크린샷 2023-03-13 오후 10 15 16" src="https://user-images.githubusercontent.com/113018070/224712496-88a804dd-c9b5-4d66-b142-23bab2efe81b.png">

- 댓글이 하나도 없는 경우에는 모임 공개, 비공개 여부 관계없이 일괄적으로 아래 이미지처럼 보이도록 했습니다.

<img width="452" alt="스크린샷 2023-03-13 오후 10 19 07" src="https://user-images.githubusercontent.com/113018070/224713468-67196c31-f3c3-4254-8959-d6f5616f8b60.png">

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help


# 관련 이슈

- Close #212 
