### PR TITLE
[#290] 모임 목록 페이지 무한스크롤 구현

### DIFF
--- a/src/apis/group/index.ts
+++ b/src/apis/group/index.ts
@@ -9,13 +9,10 @@ import {
 import { publicApi } from '../core/axios';
 
 const GroupAPI = {
-  getEntireGroups: () =>
-    publicApi.get<APIGroupPagination>(`/service-api/book-groups`, {
-      params: {
-        pageSize: 100,
-        sortDirection: 'DESC',
-      },
-    }),
+  getEntireGroups: (pageParam: string) =>
+    publicApi.get<APIGroupPagination>(
+      `/service-api/book-groups?pageSize=10&groupCursorId=` + pageParam
+    ),
 
   createGroup: ({ group }: { group: APICreateGroup }) =>
     publicApi.post('/service-api/book-groups', group),

--- a/src/pages/group/index.tsx
+++ b/src/pages/group/index.tsx
@@ -75,7 +75,7 @@ const GroupPage = () => {
           })}
       </Box>
       <Box ref={ref} />
-      {isFetchingNextPage ? <Box>Loading...</Box> : null}
+      {isFetchingNextPage && <Skeleton w="100%" height="28rem" />}
     </VStack>
   );
 };

--- a/src/pages/group/index.tsx
+++ b/src/pages/group/index.tsx
@@ -75,7 +75,7 @@ const GroupPage = () => {
             return <GroupList key={idx} bookGroups={groups.bookGroups} />;
           })}
       </Box>
-      {isFetching && !isFetchingNextPage ? null : <Box ref={ref} />}
+      <Box ref={ref} />
       {isFetching && isFetchingNextPage ? <Box>Loading...</Box> : null}
     </VStack>
   );

--- a/src/pages/group/index.tsx
+++ b/src/pages/group/index.tsx
@@ -61,9 +61,6 @@ const GroupPage = () => {
       </VStack>
     );
 
-  console.log('isFetching', isFetching);
-  console.log('isFetchingNextPage', isFetchingNextPage);
-
   return (
     <VStack align="center">
       <Box w="100%">

--- a/src/pages/group/index.tsx
+++ b/src/pages/group/index.tsx
@@ -25,7 +25,6 @@ const GroupPage = () => {
     isLoading,
     fetchNextPage,
     hasNextPage,
-    isFetching,
     isFetchingNextPage,
   } = useEntireGroupsQuery();
 
@@ -76,7 +75,7 @@ const GroupPage = () => {
           })}
       </Box>
       <Box ref={ref} />
-      {isFetching && isFetchingNextPage ? <Box>Loading...</Box> : null}
+      {isFetchingNextPage ? <Box>Loading...</Box> : null}
     </VStack>
   );
 };

--- a/src/queries/group/useEntireGroupsQuery/index.tsx
+++ b/src/queries/group/useEntireGroupsQuery/index.tsx
@@ -1,9 +1,16 @@
 import GroupAPI from '@/apis/group';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 const useEntireGroupsQuery = () =>
-  useQuery(['entireGroups'], () =>
-    GroupAPI.getEntireGroups().then(({ data }) => data)
+  useInfiniteQuery(
+    ['entireGroups'],
+    ({ pageParam = '' }) =>
+      GroupAPI.getEntireGroups(pageParam).then(({ data }) => data),
+    {
+      getNextPageParam: lastPage =>
+        !lastPage.isLast ? lastPage.bookGroups[9].bookGroupId : undefined,
+      staleTime: 3000,
+    }
   );
 
 export default useEntireGroupsQuery;


### PR DESCRIPTION
# 구현 내용

모임 목록 페이지 무한스크롤 구현

# 스크린샷

![bookGroupLists-infiniteScroll](https://user-images.githubusercontent.com/113018070/229445893-400afc1e-2ee8-478b-91f2-4e27f1fad2cd.gif)


# pr 포인트

- 바닥에 닿았을 때 Loading과 관련된 처리를 해주어야 하는데, Skeleton 컴포넌트를 넣을 경우 영역은 차지하게 되는데 Skeleton이 적용되지 않는 것을 확인했습니다. 혹시 Skeleton으로 적용할 수 있는 방법이 있을까요?
- Loading... 문구로 Loading 처리를 하여도 깔끔해 보인다는 생각이 들었는데 이 방법도 괜찮을까요? 다른 분들 의견이 궁금합니다.😁

# Help

# 관련 이슈

- Close #290 
