### PR TITLE
[#321] 최근 검색어 기능 구현

### DIFF
--- a/src/apis/book/index.ts
+++ b/src/apis/book/index.ts
@@ -7,6 +7,7 @@ import type {
   APIPatchBookCommentRequest,
   APISearchedBook,
   APISearchedBookPagination,
+  APIRecentSearches,
 } from '@/types/book';
 import bookshelfAPI from '../bookshelf';
 import { publicApi } from '../core/axios';
@@ -24,6 +25,13 @@ const bookAPI = {
     publicApi.get<APISearchedBookPagination>(
       `/service-api/books?query=${query}&page=${page}&pageSize=${pageSize}`
     ),
+
+  getRecentSearches: () =>
+    publicApi.get<APIRecentSearches>('/service-api/books/recent-searches', {
+      params: {
+        limit: 10,
+      },
+    }),
 
   getBookInfo: (bookId: APIBook['bookId']) =>
     publicApi.get<APIBookDetail>(`/service-api/books/${bookId}`),

--- a/src/queries/book/useRecentSearchesQuery.ts
+++ b/src/queries/book/useRecentSearchesQuery.ts
@@ -1,0 +1,9 @@
+import bookAPI from '@/apis/book';
+import { useQuery } from '@tanstack/react-query';
+
+const useRecentSearchesQuery = () =>
+  useQuery(['keywords'], () =>
+    bookAPI.getRecentSearches().then(({ data }) => data)
+  );
+
+export default useRecentSearchesQuery;

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -21,6 +21,17 @@ export interface APISearchedBook
   apiProvider: string;
 }
 
+export interface APISearchedWordInfo {
+  keyword: string;
+  createdAt: string;
+}
+
+export interface APIRecentSearches {
+  count: number;
+  isEmpty: boolean;
+  bookRecentSearchResponses: APISearchedWordInfo[];
+}
+
 export interface APISearchedBookPagination {
   searchBookResponseList: APISearchedBook[];
   requestedPageNumber: number;

--- a/src/ui/BookSearch/RecentSearches.tsx
+++ b/src/ui/BookSearch/RecentSearches.tsx
@@ -18,11 +18,12 @@ const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
       {searchedWords ? (
         <Flex width="100%" gap="1rem" overflowX="scroll" pb="3rem">
           {searchedWords &&
-            searchedWords.map((searchedWord, idx) => {
-              const { keyword } = searchedWord;
+            searchedWords.map(searchedWord => {
+              const { keyword, createdAt } = searchedWord;
+
               return (
                 <Text
-                  key={idx}
+                  key={createdAt}
                   whiteSpace="nowrap"
                   fontSize="md"
                   mr="0.5rem"

--- a/src/ui/BookSearch/RecentSearches.tsx
+++ b/src/ui/BookSearch/RecentSearches.tsx
@@ -1,7 +1,11 @@
 import { Flex, Text, Box } from '@chakra-ui/react';
 
+interface searchedWordsProps {
+  keyword: string;
+  createdAt: string;
+}
 interface RecentSearchesProps {
-  searchedWords: string[];
+  searchedWords: searchedWordsProps[] | undefined;
   setKeyword: (searchedWord: string) => void;
 }
 
@@ -11,28 +15,35 @@ const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
       <Box width="100%" fontSize="sm" color="black.700">
         <Text my="1rem">최근 검색어</Text>
       </Box>
-      <Flex width="100%" gap="1rem" overflowX="scroll" pb="3rem">
-        {searchedWords &&
-          searchedWords.map(searchedWord => {
-            return (
-              <Text
-                key={searchedWord}
-                whiteSpace="nowrap"
-                fontSize="md"
-                mr="0.5rem"
-                px="1.5rem"
-                borderRadius="1.5rem"
-                bgColor="white.700"
-                onClick={() => {
-                  setKeyword(searchedWord);
-                }}
-                cursor="pointer"
-              >
-                {searchedWord}
-              </Text>
-            );
-          })}
-      </Flex>
+      {searchedWords ? (
+        <Flex width="100%" gap="1rem" overflowX="scroll" pb="3rem">
+          {searchedWords &&
+            searchedWords.map(searchedWord => {
+              const { keyword } = searchedWord;
+              return (
+                <Text
+                  key={keyword}
+                  whiteSpace="nowrap"
+                  fontSize="md"
+                  mr="0.5rem"
+                  px="1.5rem"
+                  borderRadius="1.5rem"
+                  bgColor="white.700"
+                  onClick={() => {
+                    setKeyword(keyword);
+                  }}
+                  cursor="pointer"
+                >
+                  {keyword}
+                </Text>
+              );
+            })}
+        </Flex>
+      ) : (
+        <Box fontSize="sm" color="black.600">
+          <Text mb="1rem">검색 기록이 없습니다.</Text>
+        </Box>
+      )}
     </>
   );
 };

--- a/src/ui/BookSearch/RecentSearches.tsx
+++ b/src/ui/BookSearch/RecentSearches.tsx
@@ -1,7 +1,5 @@
 import { Flex, Text, Box } from '@chakra-ui/react';
 
-import { useAuth } from '@/hooks/auth';
-
 interface searchedWordsProps {
   keyword: string;
   createdAt: string;
@@ -12,12 +10,6 @@ interface RecentSearchesProps {
 }
 
 const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
-  const { isAuthed } = useAuth();
-
-  const guideText = isAuthed
-    ? '검색 기록이 없습니다.'
-    : '로그인 후 확인해 주세요.';
-
   return (
     <>
       <Box width="100%" fontSize="sm" color="black.700">
@@ -26,11 +18,11 @@ const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
       {searchedWords ? (
         <Flex width="100%" gap="1rem" overflowX="scroll" pb="3rem">
           {searchedWords &&
-            searchedWords.map(searchedWord => {
+            searchedWords.map((searchedWord, idx) => {
               const { keyword } = searchedWord;
               return (
                 <Text
-                  key={keyword}
+                  key={idx}
                   whiteSpace="nowrap"
                   fontSize="md"
                   mr="0.5rem"
@@ -49,7 +41,7 @@ const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
         </Flex>
       ) : (
         <Box fontSize="sm" color="black.600">
-          <Text mb="1.5rem">{guideText}</Text>
+          <Text mb="1.5rem">검색 기록이 없습니다.</Text>
         </Box>
       )}
     </>

--- a/src/ui/BookSearch/RecentSearches.tsx
+++ b/src/ui/BookSearch/RecentSearches.tsx
@@ -1,5 +1,7 @@
 import { Flex, Text, Box } from '@chakra-ui/react';
 
+import { useAuth } from '@/hooks/auth';
+
 interface searchedWordsProps {
   keyword: string;
   createdAt: string;
@@ -10,6 +12,12 @@ interface RecentSearchesProps {
 }
 
 const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
+  const { isAuthed } = useAuth();
+
+  const guideText = isAuthed
+    ? '검색 기록이 없습니다.'
+    : '로그인 후 확인해 주세요.';
+
   return (
     <>
       <Box width="100%" fontSize="sm" color="black.700">
@@ -41,7 +49,7 @@ const RecentSearches = ({ searchedWords, setKeyword }: RecentSearchesProps) => {
         </Flex>
       ) : (
         <Box fontSize="sm" color="black.600">
-          <Text mb="1rem">검색 기록이 없습니다.</Text>
+          <Text mb="1.5rem">{guideText}</Text>
         </Box>
       )}
     </>

--- a/src/ui/BookSearch/index.tsx
+++ b/src/ui/BookSearch/index.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 
 import type { APIBook } from '@/types/book';
 import useBookSearchQuery from '@/queries/book/useBookSearchQuery';
+import useRecentSearchesQuery from '@/queries/book/useRecentSearchesQuery';
 import { useInView } from 'react-intersection-observer';
 import useDebounceValue from '@/hooks/useDebounce';
 import SearchedBook from './SearchedBook';
@@ -49,6 +50,14 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
       page: 1,
       pageSize: 12,
     });
+
+  //로그인, 비로그인 어떤 식으로 요청이 오고 가는 것인지?
+  //헤더에 토큰을 담지 않은 경우에 알아서 로그인 유저인지 비로그인 유저인지 구별할 수 있는 것인가?
+  //검색어 post API가 별도로 있는 것인지?
+  const recentSearches = useRecentSearchesQuery();
+  console.log(recentSearches.data);
+  console.log(recentSearches.isError);
+  console.log(recentSearches.isSuccess);
 
   const searchedBooks = isSuccess
     ? data.pages.flatMap(page => page.searchBookResponseList)

--- a/src/ui/BookSearch/index.tsx
+++ b/src/ui/BookSearch/index.tsx
@@ -18,22 +18,6 @@ import useDebounceValue from '@/hooks/useDebounce';
 import SearchedBook from './SearchedBook';
 import RecentSearches from './RecentSearches';
 
-const TEMP_SEARCHES_DATA = [
-  '정의',
-  '사랑',
-  '추억',
-  '계란후라이',
-  '으라챠챠',
-  '우당탕탕',
-  '미유커피',
-  '마이마이쮸',
-  '하이',
-  '나루토',
-  '보루토',
-  '스미마셍',
-  '노인과 바다',
-];
-
 interface BookSearchProps {
   onBookClick?: (bookId: APIBook) => void;
 }
@@ -51,17 +35,19 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
       pageSize: 12,
     });
 
-  //로그인, 비로그인 어떤 식으로 요청이 오고 가는 것인지?
-  //헤더에 토큰을 담지 않은 경우에 알아서 로그인 유저인지 비로그인 유저인지 구별할 수 있는 것인가?
-  //검색어 post API가 별도로 있는 것인지?
-  const recentSearches = useRecentSearchesQuery();
-  console.log(recentSearches.data);
-  console.log(recentSearches.isError);
-  console.log(recentSearches.isSuccess);
+  const {
+    data: recentSearchesData,
+    isSuccess: recentSearchesQueryIsSuccess,
+    refetch: recentSearchesQueryRefetch,
+  } = useRecentSearchesQuery();
 
   const searchedBooks = isSuccess
     ? data.pages.flatMap(page => page.searchBookResponseList)
     : [];
+
+  const recentSearches = recentSearchesQueryIsSuccess
+    ? recentSearchesData.bookRecentSearchResponses
+    : undefined;
 
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target) return;
@@ -73,7 +59,14 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
     if (inView && hasNextPage) {
       fetchNextPage();
     }
-  }, [fetchNextPage, inView, hasNextPage]);
+    recentSearchesQueryRefetch();
+  }, [
+    fetchNextPage,
+    inView,
+    hasNextPage,
+    recentSearchesQueryRefetch,
+    queryKeyword,
+  ]);
 
   return (
     <VStack w="100%">
@@ -97,7 +90,7 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
         />
       </InputGroup>
       <RecentSearches
-        searchedWords={TEMP_SEARCHES_DATA}
+        searchedWords={recentSearches}
         setKeyword={setInputValue}
       />
 

--- a/src/ui/BookSearch/index.tsx
+++ b/src/ui/BookSearch/index.tsx
@@ -28,25 +28,20 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
 
   const { ref, inView } = useInView();
 
-  const { data, isSuccess, isFetching, hasNextPage, fetchNextPage } =
-    useBookSearchQuery({
-      query: queryKeyword,
-      page: 1,
-      pageSize: 12,
-    });
+  const bookSearchInfo = useBookSearchQuery({
+    query: queryKeyword,
+    page: 1,
+    pageSize: 12,
+  });
 
-  const {
-    data: recentSearchesData,
-    isSuccess: recentSearchesQueryIsSuccess,
-    refetch: recentSearchesQueryRefetch,
-  } = useRecentSearchesQuery();
+  const recentSearchesInfo = useRecentSearchesQuery();
 
-  const searchedBooks = isSuccess
-    ? data.pages.flatMap(page => page.searchBookResponseList)
+  const searchedBooks = bookSearchInfo.isSuccess
+    ? bookSearchInfo.data.pages.flatMap(page => page.searchBookResponseList)
     : [];
 
-  const recentSearches = recentSearchesQueryIsSuccess
-    ? recentSearchesData.bookRecentSearchResponses
+  const recentSearches = recentSearchesInfo.isSuccess
+    ? recentSearchesInfo.data.bookRecentSearchResponses
     : undefined;
 
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -56,16 +51,17 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
   };
 
   useEffect(() => {
-    if (inView && hasNextPage) {
-      fetchNextPage();
+    if (inView && bookSearchInfo.hasNextPage) {
+      bookSearchInfo.fetchNextPage();
     }
-    recentSearchesQueryRefetch();
+    recentSearchesInfo.refetch();
   }, [
-    fetchNextPage,
+    bookSearchInfo.fetchNextPage,
     inView,
-    hasNextPage,
-    recentSearchesQueryRefetch,
+    bookSearchInfo.hasNextPage,
     queryKeyword,
+    bookSearchInfo,
+    recentSearchesInfo,
   ]);
 
   return (
@@ -100,7 +96,7 @@ const BookSearch = ({ onBookClick }: BookSearchProps) => {
         ))}
       </SimpleGrid>
 
-      {isFetching && (
+      {bookSearchInfo.isFetching && (
         <Flex gap="1rem" w="100%">
           <Skeleton w="100%" h="18rem" borderRadius={10} />
           <Skeleton w="100%" h="18rem" borderRadius={10} />


### PR DESCRIPTION
# 구현 내용

- 최근 검색어 기능 구현

# 스크린샷

![최근 검색어 기능 구현](https://user-images.githubusercontent.com/113018070/235849241-b8812621-3f4d-4b14-a81a-dec0ea4db2e3.gif)

# pr 포인트

- 도서 검색 쿼리와 최근 검색어 쿼리가 둘 다 사용되어 코드의 통일성과 명확성을 위해 구조 분해 할당으로 꺼내온 데이터들을 명시적으로 보일 수 있도록 수정했습니다. ex) const bookSearchInfo = useBookSearchQuery({...})로 수정하여 bookSearchInfo.isSuccess

# Help

- 현재 API에 맞게 기능을 구현했으나 아직 삭제 및 전체 삭제 기능은 없고, 이미 최근 검색어로 들어가 있는 단어를 다시 검색하는 경우 해당 단어가 다시 0번 인덱스로 이동되어야 하나 해당 기능까지 백엔드에서 아직 구현하지는 않은것 같습니다. 
- 다독다독 서비스의 경우 책 검색에서 디바운스를 통해 자동으로 단어들을 검색하고 있는데, 해당 기능과 최근 검색어 기능과 어울리지는 않는 것 같습니다. submit을 통해 명확하게 검색을 하는 방식으로 변경할 필요가 있을 것 같습니다. 
- 참고 부탁드립니다. 감사합니다~☺️

# 관련 이슈

- Close #321 
