### PR TITLE
[#347] 로그인하지 않은 사용자가 책 상세 페이지에서 내용을 보지 못하는 문제 해결

### DIFF
--- a/src/pages/book/[bookId]/index.tsx
+++ b/src/pages/book/[bookId]/index.tsx
@@ -9,7 +9,6 @@ import { APIBook } from '@/types/book';
 import { BookCommentList, BookInfo } from '@/ui/BookDetail';
 import TopNavigation from '@/ui/common/TopNavigation';
 import debounce from '@/utils/debounce';
-import { isAuthed } from '@/utils/helpers';
 
 const BookDetailPage = ({ bookId }: { bookId: APIBook['bookId'] }) => {
   const router = useRouter();
@@ -21,9 +20,7 @@ const BookDetailPage = ({ bookId }: { bookId: APIBook['bookId'] }) => {
     },
   });
 
-  const bookUserQueryInfo = useBookUserInfoQuery(bookId, {
-    enabled: isAuthed(),
-  });
+  const bookUserQueryInfo = useBookUserInfoQuery(bookId);
 
   const updateBookmark = (isBookMarked: boolean) => {
     if (!bookUserQueryInfo.isSuccess) {

--- a/src/ui/BookDetail/BookInfo.tsx
+++ b/src/ui/BookDetail/BookInfo.tsx
@@ -61,8 +61,19 @@ const BookInfo = ({
   return (
     <>
       <Flex gap="2rem" align="flex-end">
-        <Box shadow="lg">
-          <Image src={imageUrl} alt="book" width={180} height={240} />
+        <Box
+          shadow="lg"
+          position="relative"
+          width="18rem"
+          height="24rem"
+          flexShrink={0}
+        >
+          <Image
+            src={imageUrl.replace('R120x174.q85', 'R300x0.q100')}
+            alt="book"
+            fill
+            sizes="300px"
+          />
         </Box>
         <VStack align="flex-start">
           <IconButton


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

* `useBookUserInfoQuery` 의 enabled 옵션을 제거하여 로그인하지 않은 사용자가 책 상세 페이지에서 내용을 보지 못하는 문제를 해결했어요.
* 책 상세 페이지에서 더 높은 해상도의 책 표지를 받아오도록 수정했어요.

# 스크린샷

<img width="1912" alt="image" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/48359052/0d4965c8-add9-436a-86d1-d831952f0956">

# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #347 
