### PR TITLE
[#365] Modal 컴포넌트

### DIFF
--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useDisclosure = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const onOpen = () => {
+    setIsOpen(true);
+  };
+
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  return { isOpen, onOpen, onClose };
+};
+
+export default useDisclosure;

--- a/src/stories/Base/Modal.stories.tsx
+++ b/src/stories/Base/Modal.stories.tsx
@@ -18,7 +18,7 @@ const BaseModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <Fragment>
+    <>
       <Button
         onClick={() => {
           onOpen();
@@ -27,7 +27,7 @@ const BaseModal = () => {
         Open Modal
       </Button>
       <Modal isOpen={isOpen} onClose={onClose}></Modal>
-    </Fragment>
+    </>
   );
 };
 
@@ -40,7 +40,7 @@ const DeleteModal = () => {
   };
 
   return (
-    <Fragment>
+    <>
       <Button
         onClick={() => {
           onOpen();
@@ -55,7 +55,7 @@ const DeleteModal = () => {
             한번 삭제하면 되돌릴 수 없어요.
           </p>
         </div>
-        <div className="flex justify-end gap-[10px]">
+        <div className="flex justify-end gap-[1rem]">
           <Button
             onClick={onClose}
             fill={false}
@@ -69,7 +69,7 @@ const DeleteModal = () => {
           </Button>
         </div>
       </Modal>
-    </Fragment>
+    </>
   );
 };
 

--- a/src/stories/Base/Modal.stories.tsx
+++ b/src/stories/Base/Modal.stories.tsx
@@ -26,16 +26,16 @@ const BaseModal = () => {
       >
         Open Modal
       </Button>
-      <Modal isOpen={isOpen} close={onClose}></Modal>
+      <Modal isOpen={isOpen} onClose={onClose}></Modal>
     </Fragment>
   );
 };
 
-const DeleteMeetingModal = () => {
+const DeleteModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const handleClick = () => {
-    alert('삭제했습니다.');
+    alert('삭제되었습니다.');
     onClose();
   };
 
@@ -48,9 +48,9 @@ const DeleteMeetingModal = () => {
       >
         Open Modal
       </Button>
-      <Modal isOpen={isOpen} close={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose}>
         <div className="text-lg font-bold">
-          모임을 정말 삭제할까요?
+          정말 삭제할까요?
           <p className="text-xs font-normal text-black-500">
             한번 삭제하면 되돌릴 수 없어요.
           </p>
@@ -65,7 +65,7 @@ const DeleteMeetingModal = () => {
             취소
           </Button>
           <Button onClick={handleClick} size="small">
-            삭제
+            확인
           </Button>
         </div>
       </Modal>
@@ -77,6 +77,6 @@ export const Default: Story = {
   render: () => <BaseModal />,
 };
 
-export const DeleteCase: Story = {
-  render: () => <DeleteMeetingModal />,
+export const Delete: Story = {
+  render: () => <DeleteModal />,
 };

--- a/src/stories/Base/Modal.stories.tsx
+++ b/src/stories/Base/Modal.stories.tsx
@@ -1,0 +1,44 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Modal from '@/ui/Base/Modal';
+import { useState } from 'react';
+import Button from '@/ui/Base/Button';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Base/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+const DeleteMeetingModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const deleteHandler = () => {
+    alert('삭제 되었습니다.');
+  };
+
+  return (
+    <div>
+      <Button
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      >
+        Open Modal
+      </Button>
+      <Modal
+        title="모임"
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        deleteHandler={deleteHandler}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <DeleteMeetingModal />,
+};

--- a/src/stories/Base/Modal.stories.tsx
+++ b/src/stories/Base/Modal.stories.tsx
@@ -1,7 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import Modal from '@/ui/Base/Modal';
-import { useState } from 'react';
+import useDisclosure from '@/hooks/useDisclosure';
 import Button from '@/ui/Base/Button';
+import { Fragment } from 'react';
 
 const meta: Meta<typeof Modal> = {
   title: 'Base/Modal',
@@ -13,32 +14,69 @@ export default meta;
 
 type Story = StoryObj<typeof Modal>;
 
-const DeleteMeetingModal = () => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const deleteHandler = () => {
-    alert('삭제 되었습니다.');
-  };
+const BaseModal = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <div>
+    <Fragment>
       <Button
         onClick={() => {
-          setIsOpen(true);
+          onOpen();
         }}
       >
         Open Modal
       </Button>
-      <Modal
-        title="모임"
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        deleteHandler={deleteHandler}
-      />
-    </div>
+      <Modal isOpen={isOpen} close={onClose}></Modal>
+    </Fragment>
+  );
+};
+
+const DeleteMeetingModal = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleClick = () => {
+    alert('삭제했습니다.');
+    onClose();
+  };
+
+  return (
+    <Fragment>
+      <Button
+        onClick={() => {
+          onOpen();
+        }}
+      >
+        Open Modal
+      </Button>
+      <Modal isOpen={isOpen} close={onClose}>
+        <div className="text-lg font-bold">
+          모임을 정말 삭제할까요?
+          <p className="text-xs font-normal text-black-500">
+            한번 삭제하면 되돌릴 수 없어요.
+          </p>
+        </div>
+        <div className="flex justify-end gap-[10px]">
+          <Button
+            onClick={onClose}
+            fill={false}
+            colorScheme="grey"
+            size="small"
+          >
+            취소
+          </Button>
+          <Button onClick={handleClick} size="small">
+            삭제
+          </Button>
+        </div>
+      </Modal>
+    </Fragment>
   );
 };
 
 export const Default: Story = {
+  render: () => <BaseModal />,
+};
+
+export const DeleteCase: Story = {
   render: () => <DeleteMeetingModal />,
 };

--- a/src/ui/Base/Modal.tsx
+++ b/src/ui/Base/Modal.tsx
@@ -1,0 +1,79 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment } from 'react';
+import Button from '@/ui/Base/Button';
+
+interface ModalProps {
+  title: string;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  deleteHandler: () => void;
+}
+
+const Modal = ({ title, isOpen, setIsOpen, deleteHandler }: ModalProps) => {
+  const closeButtonHandler = () => {
+    setIsOpen(false);
+  };
+
+  const deleteButtonHandler = () => {
+    setIsOpen(false);
+    deleteHandler();
+  };
+
+  return (
+    <>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog as="div" className="relative z-10" onClose={closeButtonHandler}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black-900 bg-opacity-30" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-300"
+                enterFrom="opacity-0 scale-95"
+                enterTo="opacity-100 scale-100"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-100 scale-100"
+                leaveTo="opacity-0 scale-95"
+              >
+                <Dialog.Panel className="flex w-[313px] transform flex-col gap-[25px] overflow-hidden rounded-[4px] bg-white px-[25px] py-[20px] transition-all">
+                  <Dialog.Title as="div" className="text-lg font-bold">
+                    {title}을 정말 삭제할까요?
+                    <p className="text-xs font-normal text-black-500">
+                      한번 삭제하면 되돌릴 수 없어요.
+                    </p>
+                  </Dialog.Title>
+                  <div className="flex justify-end gap-[10px]">
+                    <Button
+                      onClick={closeButtonHandler}
+                      fill={false}
+                      colorScheme="grey"
+                      size="small"
+                    >
+                      취소
+                    </Button>
+                    <Button onClick={deleteButtonHandler} size="small">
+                      삭제
+                    </Button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  );
+};
+
+export default Modal;

--- a/src/ui/Base/Modal.tsx
+++ b/src/ui/Base/Modal.tsx
@@ -9,41 +9,39 @@ interface ModalProps {
 
 const Modal = ({ isOpen, onClose, children }: ModalProps) => {
   return (
-    <>
-      <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-10" onClose={onClose}>
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-black-900 bg-opacity-30" />
-          </Transition.Child>
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black-900 bg-opacity-30" />
+        </Transition.Child>
 
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center">
-              <Transition.Child
-                as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
-                <Dialog.Panel className="flex w-[313px] transform flex-col gap-[25px] overflow-hidden rounded-[4px] bg-white px-[25px] py-[20px] transition-all">
-                  {children}
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="flex w-[313px] transform flex-col gap-[25px] overflow-hidden rounded-[4px] bg-white px-[25px] py-[20px] transition-all">
+                {children}
+              </Dialog.Panel>
+            </Transition.Child>
           </div>
-        </Dialog>
-      </Transition>
-    </>
+        </div>
+      </Dialog>
+    </Transition>
   );
 };
 

--- a/src/ui/Base/Modal.tsx
+++ b/src/ui/Base/Modal.tsx
@@ -3,15 +3,15 @@ import { Fragment, ReactNode } from 'react';
 
 interface ModalProps {
   isOpen: boolean;
-  close: () => void;
+  onClose: () => void;
   children?: ReactNode;
 }
 
-const Modal = ({ isOpen, close, children }: ModalProps) => {
+const Modal = ({ isOpen, onClose, children }: ModalProps) => {
   return (
     <>
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-10" onClose={close}>
+        <Dialog as="div" className="relative z-10" onClose={onClose}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"

--- a/src/ui/Base/Modal.tsx
+++ b/src/ui/Base/Modal.tsx
@@ -1,28 +1,17 @@
 import { Dialog, Transition } from '@headlessui/react';
-import { Fragment } from 'react';
-import Button from '@/ui/Base/Button';
+import { Fragment, ReactNode } from 'react';
 
 interface ModalProps {
-  title: string;
   isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
-  deleteHandler: () => void;
+  close: () => void;
+  children?: ReactNode;
 }
 
-const Modal = ({ title, isOpen, setIsOpen, deleteHandler }: ModalProps) => {
-  const closeButtonHandler = () => {
-    setIsOpen(false);
-  };
-
-  const deleteButtonHandler = () => {
-    setIsOpen(false);
-    deleteHandler();
-  };
-
+const Modal = ({ isOpen, close, children }: ModalProps) => {
   return (
     <>
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-10" onClose={closeButtonHandler}>
+        <Dialog as="div" className="relative z-10" onClose={close}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -47,25 +36,7 @@ const Modal = ({ title, isOpen, setIsOpen, deleteHandler }: ModalProps) => {
                 leaveTo="opacity-0 scale-95"
               >
                 <Dialog.Panel className="flex w-[313px] transform flex-col gap-[25px] overflow-hidden rounded-[4px] bg-white px-[25px] py-[20px] transition-all">
-                  <Dialog.Title as="div" className="text-lg font-bold">
-                    {title}을 정말 삭제할까요?
-                    <p className="text-xs font-normal text-black-500">
-                      한번 삭제하면 되돌릴 수 없어요.
-                    </p>
-                  </Dialog.Title>
-                  <div className="flex justify-end gap-[10px]">
-                    <Button
-                      onClick={closeButtonHandler}
-                      fill={false}
-                      colorScheme="grey"
-                      size="small"
-                    >
-                      취소
-                    </Button>
-                    <Button onClick={deleteButtonHandler} size="small">
-                      삭제
-                    </Button>
-                  </div>
+                  {children}
                 </Dialog.Panel>
               </Transition.Child>
             </div>

--- a/src/ui/Base/Modal.tsx
+++ b/src/ui/Base/Modal.tsx
@@ -20,7 +20,7 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black-900 bg-opacity-30" />
+          <div className="fixed inset-0 bg-overlay bg-opacity-60" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -34,7 +34,7 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="flex w-[313px] transform flex-col gap-[25px] overflow-hidden rounded-[4px] bg-white px-[25px] py-[20px] transition-all">
+              <Dialog.Panel className="flex w-[31.3rem] transform flex-col gap-[2.5rem] overflow-hidden rounded-[0.4rem] bg-white px-[2.5rem] py-[2rem] transition-all">
                 {children}
               </Dialog.Panel>
             </Transition.Child>


### PR DESCRIPTION
# 구현 내용

- Modal 컴포넌트 작성

# 스크린샷

![chrome-capture-2023-6-30 (1)](https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/113018070/a4f04094-237f-41ec-bebf-dbcf856e132c)

# pr 포인트

~~Modal 컴포넌트는 온전하게 UI로의 역할만 할 수 있게 Modal을 control하는 상태들은 전부 사용하고자 하는 컴포넌트에서 prop으로 넘겨주도록 했고,~~

~~modal 창이 띄워진 후 삭제 버튼 클릭시의 동작도 필요하기에 그에 따른 동작도 prop으로 넘겨 받도록 구현했는데 괜찮은 방법인지 모르겠습니다. 어떻게 생각하시나요?!~~

- Modal 컴포넌트는 오직 모달창이 띄워지는 역할만 할 수 있도록 수정했습니다.

- modal 창이 띄워졌을 때 내부의 제목, 내용, 버튼과 같은 요소는 Modal 컴포넌트를 사용하는 측에서 children으로 넘겨 줄 수 있도록 했습니다.

- useDisclosure 훅을 통해 modal의 isOpen 상태를 관리하도록 변경하였습니다.

- Modal 컴포넌트에 portal을 적용하기 위해 알아보던 중 `headlessui`의 `Modal`을 사용하면 portal을 사용해 Modal을 렌더링하고 있어 별도로 portal을 사용하지는 않았습니다. body 요소 내부에 `id`가 `headlessui-portal-root`라는 `div` 요소를 생성하여 그 안에 Modal 컴포넌트가 들어가고 있습니다.

# modal open 전
![스크린샷 2023-07-30 오후 3 05 47](https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/113018070/9167e890-6f88-4d01-9610-43214f121be7)

# modal open 후
![스크린샷 2023-07-30 오후 3 06 31](https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/113018070/96485c44-7908-4c7b-bcd3-90ccd229e419)


# Help

~~Modal 컴포넌트는 모임삭제 / 댓글삭제 / 책 코멘트 삭제에서 사용될 것으로 예상됩니다.
그런데 title에 따라 *목적격 조사*가 달라지게 되는데 (ex 모임`을`, 댓글`을`, 코멘트`를` ) 이를 통일 시켜주는 방법이 뭐가 좋을지 고민입니다.그렇다고 title props에 -을/-를 까지 붙여 넘겨주는 것은 어색한 것 같고..
좋은 방법 없을까요?~~
  
- Modal 컴포넌트에 props로 넘기는 것을 최소화하는 것을 목표로 구현하였는데, 더 좋은 방법 있다면 말씀해주세요! 바로 수정 작업하겠습니다. 🤗

# 관련 이슈

- Close #365
