### PR TITLE
[#398] RadioButton 컴포넌트

### DIFF
--- a/src/stories/Base/RadioButton.stories.tsx
+++ b/src/stories/Base/RadioButton.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import RadioButton from '@/ui/Base/RadioButton';
+import Button from '@/ui/Base/Button';
+
+const meta: Meta<typeof RadioButton> = {
+  title: 'Base/RadioButton',
+  component: RadioButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RadioButton>;
+
+type FormValues = {
+  Radio: string;
+};
+
+const RadioButtonWithUseForm = () => {
+  const { register, handleSubmit, watch } = useForm<FormValues>({
+    mode: 'all',
+    defaultValues: { Radio: '라디오 A' },
+  });
+
+  const handleSubmitForm: SubmitHandler<FormValues> = ({ Radio }) => {
+    alert(`Submit as: ${Radio}`);
+  };
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit(handleSubmitForm)}
+        className="flex w-[43rem] flex-col gap-[1.6rem]"
+      >
+        <div className="flex justify-between">
+          <RadioButton {...register('Radio')} value="라디오 A" />
+          <RadioButton {...register('Radio')} value="라디오 B" />
+          <RadioButton {...register('Radio')} value="라디오 C" />
+        </div>
+        <Button size="large" type="submit">
+          Submit
+        </Button>
+      </form>
+      <pre>{JSON.stringify(watch(), null, 2)}</pre>
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: args => <RadioButton {...args} value="라디오 버튼" />,
+};
+
+export const RadioButtonForm: Story = {
+  render: RadioButtonWithUseForm,
+};

--- a/src/stories/Base/RadioButton.stories.tsx
+++ b/src/stories/Base/RadioButton.stories.tsx
@@ -15,17 +15,17 @@ export default meta;
 type Story = StoryObj<typeof RadioButton>;
 
 type FormValues = {
-  Radio: string;
+  radio: string;
 };
 
 const RadioButtonWithUseForm = () => {
   const { register, handleSubmit, watch } = useForm<FormValues>({
     mode: 'all',
-    defaultValues: { Radio: '라디오 A' },
+    defaultValues: { radio: '라디오 A' },
   });
 
-  const handleSubmitForm: SubmitHandler<FormValues> = ({ Radio }) => {
-    alert(`Submit as: ${Radio}`);
+  const handleSubmitForm: SubmitHandler<FormValues> = ({ radio }) => {
+    alert(`Submit as: ${radio}`);
   };
 
   return (
@@ -35,9 +35,9 @@ const RadioButtonWithUseForm = () => {
         className="flex w-[43rem] flex-col gap-[1.6rem]"
       >
         <div className="flex justify-between">
-          <RadioButton {...register('Radio')} value="라디오 A" />
-          <RadioButton {...register('Radio')} value="라디오 B" />
-          <RadioButton {...register('Radio')} value="라디오 C" />
+          <RadioButton {...register('radio')} value="라디오 A" />
+          <RadioButton {...register('radio')} value="라디오 B" />
+          <RadioButton {...register('radio')} value="라디오 C" />
         </div>
         <Button size="large" type="submit">
           Submit

--- a/src/ui/Base/RadioButton.tsx
+++ b/src/ui/Base/RadioButton.tsx
@@ -1,0 +1,30 @@
+import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
+
+const BASE_RADIO_BUTTON_CLASSES =
+  'px-[1.2rem] py-[0.5rem] bg-main-600/[0.18] text-main-900 text-sm font-normal rounded-[2rem] cursor-pointer w-full h-full peer-checked:bg-main-900 peer-checked:text-white';
+
+const RadioButton = (
+  {
+    name,
+    value,
+    ...props
+  }: Omit<ComponentPropsWithoutRef<'input'>, 'id' | 'type' | 'className'>,
+  ref: Ref<HTMLInputElement>
+) => {
+  return (
+    <label htmlFor={`id-${value}`}>
+      <input
+        id={`id-${value}`}
+        name={name}
+        className="peer hidden"
+        type="radio"
+        value={value}
+        ref={ref}
+        {...props}
+      />
+      <span className={BASE_RADIO_BUTTON_CLASSES}>{value}</span>
+    </label>
+  );
+};
+
+export default forwardRef(RadioButton);


### PR DESCRIPTION
# 구현 내용

<!-- - ex) 결제 기능 구현 -->

# 스크린샷

<!-- 없는 경우 생략한다. -->

# pr 포인트
아티클 공유: `label`의 `htmlFor`속성과 `input`의 `name`속성을 같게 해주어야 서로 접근(?)할 수 있다! [참고 MDN 문서](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#selecting_a_radio_button_by_default)

# Help
아직은 구상이 잘 떠오르지 않습니다만
<img width="332" alt="image" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/f77d4609-e45c-412e-8c00-7407829fc7fb">

위 사진과 같이 `직접 입력`을 선택했을 때 `Input` 요소가 나올 수 있도록 하는 기능도 차차 고민해봐야할 것 같습니다!

# 관련 이슈

- Close #398 
