### PR TITLE
[fix] group 페이지 타입 에러 수정

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -78,7 +78,7 @@ const GroupPage = () => {
                   startDate,
                   endDate,
                   owner,
-                  memberCount,
+                  currentMemberCount,
                   commentCount,
                   isPublic,
                   bookGroupId,
@@ -94,7 +94,7 @@ const GroupPage = () => {
                       name: owner.nickname,
                       profileImageSrc: owner.profileUrl,
                     }}
-                    memberCount={memberCount}
+                    memberCount={currentMemberCount}
                     commentCount={commentCount}
                     isPublic={isPublic}
                     bookGroupId={bookGroupId}


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

`APIGroup` 타입 명세가 수정된 부분이 있었는데, 머지하면서 모임 메인페이지에는 적용이 되지 않아 빌드 과정에서 에러가 발생했어요. 이 부분 해결했습니다! 