### PR TITLE
[#447] [모임 상세] 모임 참여 여부, 모임장 여부에 따른 UI 구현

### DIFF
--- a/public/icons/avatar.svg
+++ b/public/icons/avatar.svg
@@ -1,9 +1,10 @@
 <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="20" height="20" rx="10" fill="#D9D9D9"/>
-<mask id="mask0_1559_6424" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+<rect width="20" height="20" rx="10" fill="#ECECEC"/>
+<mask id="mask0_1200_6956" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
 <circle cx="10" cy="10" r="10" fill="#D9D9D9"/>
 </mask>
-<g mask="url(#mask0_1559_6424)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5.3125 7.81172C5.3125 5.22292 7.41042 3.125 9.99922 3.125C12.588 3.125 14.6875 5.22292 14.6875 7.81172C14.6875 9.42344 13.8747 10.8445 12.637 11.6883C15.6539 12.7267 17.8125 15.4955 17.8125 18.7487C17.8125 22.8933 14.3134 26.25 9.9987 26.25C5.68404 26.25 2.1875 22.8933 2.1875 18.7487C2.1875 15.4952 4.34487 12.7262 7.36152 11.688C6.1245 10.8442 5.3125 9.42326 5.3125 7.81172Z" fill="white"/>
+<g mask="url(#mask0_1200_6956)">
+<path d="M6 7.99933C6 5.79023 7.79023 4 9.99933 4C12.2084 4 14 5.79023 14 7.99933C14 10.2098 12.2084 12 9.99933 12C7.79023 12 6 10.2098 6 7.99933Z" fill="#FAFAFA"/>
+<path d="M2 19.4989C2 15.9091 5.58046 13 9.99867 13C14.4169 13 18 15.9091 18 19.4989C18 23.0909 14.4169 26 9.99867 26C5.58046 26 2 23.0909 2 19.4989Z" fill="#FAFAFA"/>
 </g>
 </svg>

--- a/src/apis/core/axios.ts
+++ b/src/apis/core/axios.ts
@@ -12,8 +12,8 @@ import isClient from '@/utils/isClient';
 import webStorage from '@/utils/storage';
 
 const storage = webStorage(ACCESS_TOKEN_STORAGE_KEY);
-
 const options: CreateAxiosDefaults = {
+  baseURL: process.env.NEXT_HOST,
   headers: {
     Accept: '*/*',
     'Content-Type': 'application/json',

--- a/src/apis/group/index.ts
+++ b/src/apis/group/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@/types/group';
 import { publicApi } from '../core/axios';
 
-const GroupAPI = {
+const groupAPI = {
   getEntireGroups: (pageParam: string) =>
     publicApi.get<APIGroupPagination>(
       `/service-api/book-groups?pageSize=10&groupCursorId=` + pageParam
@@ -109,4 +109,4 @@ const GroupAPI = {
     ),
 };
 
-export default GroupAPI;
+export default groupAPI;

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
+import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+import Loading from '@/ui/Base/Loading';
 import TopNavigation from '@/ui/Base/TopNavigation';
 import BookGroupInfo from '@/v1/bookGroup/detail/BookGroupInfo';
+import CommentList from '@/v1/bookGroup/detail/CommentList';
 import { IconArrowLeft, IconHamburger, IconPost } from '@public/icons';
 
 import { useBookGroupTitle } from '@/queries/group/useBookGroupQuery';
-import CommentList from '@/v1/bookGroup/detail/CommentList';
-import { useRouter } from 'next/navigation';
 
 const DetailBookGroupPage = ({
   params: { groupId },
@@ -16,13 +19,15 @@ const DetailBookGroupPage = ({
   return (
     <>
       <BookGroupNavigation groupId={groupId} />
-      <div className="flex flex-col gap-[2rem]">
-        <BookGroupInfo groupId={groupId} />
-        <div className="flex flex-col gap-[1rem]">
-          <Heading text="게시글" />
-          <CommentList groupId={groupId} />
+      <SSRSafeSuspense fallback={<Loading fullpage />}>
+        <div className="flex flex-col gap-[2rem]">
+          <BookGroupInfo groupId={groupId} />
+          <div className="flex flex-col gap-[1rem]">
+            <Heading text="게시글" />
+            <CommentList groupId={groupId} />
+          </div>
         </div>
-      </div>
+      </SSRSafeSuspense>
     </>
   );
 };

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -69,7 +69,7 @@ const Heading = ({ text }: { text: string }) => (
 );
 
 const TitleSkeleton = () => (
-  <div className="h-[1.3rem] w-[8rem] bg-black-400"></div>
+  <div className="h-[1.3rem] w-[8rem] animate-pulse bg-black-400"></div>
 );
 
 const PageSkeleton = () => (

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -37,7 +37,7 @@ const BookGroupNavigation = ({ groupId }: { groupId: number }) => {
         <IconArrowLeft />
       </TopNavigation.LeftItem>
       <TopNavigation.CenterItem textAlign="left">
-        {title}
+        <p className="w-[90%] truncate">{title}</p>
       </TopNavigation.CenterItem>
       <TopNavigation.RightItem>
         <IconPost />

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -6,6 +6,7 @@ import { IconArrowLeft, IconHamburger, IconPost } from '@public/icons';
 
 import { useBookGroupTitle } from '@/queries/group/useBookGroupQuery';
 import CommentList from '@/v1/bookGroup/detail/CommentList';
+import { useRouter } from 'next/navigation';
 
 const DetailBookGroupPage = ({
   params: { groupId },
@@ -29,12 +30,15 @@ const DetailBookGroupPage = ({
 export default DetailBookGroupPage;
 
 const BookGroupNavigation = ({ groupId }: { groupId: number }) => {
+  const router = useRouter();
   const { data: title } = useBookGroupTitle(groupId);
 
   return (
     <TopNavigation>
       <TopNavigation.LeftItem>
-        <IconArrowLeft />
+        <a onClick={router.back}>
+          <IconArrowLeft />
+        </a>
       </TopNavigation.LeftItem>
       <TopNavigation.CenterItem textAlign="left">
         <p className="w-[90%] truncate">{title}</p>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import { ReactNode, Suspense } from 'react';
-import { useRouter } from 'next/navigation';
-
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
-import TopNavigation from '@/ui/Base/TopNavigation';
 import BookGroupInfo from '@/v1/bookGroup/detail/BookGroupInfo';
 import CommentList from '@/v1/bookGroup/detail/CommentList';
-import { IconArrowLeft, IconHamburger, IconPost } from '@public/icons';
-
-import { useBookGroupTitle } from '@/queries/group/useBookGroupQuery';
+import BookGroupNavigation from '@/v1/bookGroup/BookGroupNavigation';
+import JoinBookGroupButton from '@/v1/bookGroup/detail/JoinBookGroupButton';
 
 const DetailBookGroupPage = ({
   params: { groupId },
@@ -18,19 +13,20 @@ const DetailBookGroupPage = ({
 }) => {
   return (
     <>
-      <BookGroupNavigation>
-        <Suspense fallback={<TitleSkeleton />}>
-          <PageTitle groupId={groupId} />
-        </Suspense>
+      <BookGroupNavigation groupId={groupId}>
+        <BookGroupNavigation.BackButton />
+        <BookGroupNavigation.Title />
+        <BookGroupNavigation.WriteButton />
+        <BookGroupNavigation.MenuButton />
       </BookGroupNavigation>
+
       <SSRSafeSuspense fallback={<PageSkeleton />}>
         <div className="flex flex-col gap-[2rem]">
           <BookGroupInfo groupId={groupId} />
-          <div className="flex flex-col gap-[1rem]">
-            <Heading text="게시글" />
-            <CommentList groupId={groupId} />
-          </div>
+          <Heading text="게시글" />
+          <CommentList groupId={groupId} />
         </div>
+        <JoinBookGroupButton groupId={groupId} />
       </SSRSafeSuspense>
     </>
   );
@@ -38,38 +34,8 @@ const DetailBookGroupPage = ({
 
 export default DetailBookGroupPage;
 
-const BookGroupNavigation = ({ children }: { children: ReactNode }) => {
-  const router = useRouter();
-
-  return (
-    <TopNavigation>
-      <TopNavigation.LeftItem>
-        <a onClick={router.back}>
-          <IconArrowLeft />
-        </a>
-      </TopNavigation.LeftItem>
-      <TopNavigation.CenterItem textAlign="left">
-        {children}
-      </TopNavigation.CenterItem>
-      <TopNavigation.RightItem>
-        <IconPost />
-        <IconHamburger />
-      </TopNavigation.RightItem>
-    </TopNavigation>
-  );
-};
-
-const PageTitle = ({ groupId }: { groupId: number }) => {
-  const { data: title } = useBookGroupTitle(groupId);
-  return <p className="w-[90%] truncate">{title}</p>;
-};
-
 const Heading = ({ text }: { text: string }) => (
   <p className=" text-xl font-bold">{text}</p>
-);
-
-const TitleSkeleton = () => (
-  <div className="h-[1.3rem] w-[8rem] animate-pulse bg-black-400"></div>
 );
 
 const PageSkeleton = () => (

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { ReactNode, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
-import Loading from '@/ui/Base/Loading';
 import TopNavigation from '@/ui/Base/TopNavigation';
 import BookGroupInfo from '@/v1/bookGroup/detail/BookGroupInfo';
 import CommentList from '@/v1/bookGroup/detail/CommentList';
@@ -18,8 +18,12 @@ const DetailBookGroupPage = ({
 }) => {
   return (
     <>
-      <BookGroupNavigation groupId={groupId} />
-      <SSRSafeSuspense fallback={<Loading fullpage />}>
+      <BookGroupNavigation>
+        <Suspense fallback={<TitleSkeleton />}>
+          <PageTitle groupId={groupId} />
+        </Suspense>
+      </BookGroupNavigation>
+      <SSRSafeSuspense fallback={<PageSkeleton />}>
         <div className="flex flex-col gap-[2rem]">
           <BookGroupInfo groupId={groupId} />
           <div className="flex flex-col gap-[1rem]">
@@ -34,9 +38,8 @@ const DetailBookGroupPage = ({
 
 export default DetailBookGroupPage;
 
-const BookGroupNavigation = ({ groupId }: { groupId: number }) => {
+const BookGroupNavigation = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
-  const { data: title } = useBookGroupTitle(groupId);
 
   return (
     <TopNavigation>
@@ -46,7 +49,7 @@ const BookGroupNavigation = ({ groupId }: { groupId: number }) => {
         </a>
       </TopNavigation.LeftItem>
       <TopNavigation.CenterItem textAlign="left">
-        <p className="w-[90%] truncate">{title}</p>
+        {children}
       </TopNavigation.CenterItem>
       <TopNavigation.RightItem>
         <IconPost />
@@ -56,6 +59,27 @@ const BookGroupNavigation = ({ groupId }: { groupId: number }) => {
   );
 };
 
+const PageTitle = ({ groupId }: { groupId: number }) => {
+  const { data: title } = useBookGroupTitle(groupId);
+  return <p className="w-[90%] truncate">{title}</p>;
+};
+
 const Heading = ({ text }: { text: string }) => (
   <p className=" text-xl font-bold">{text}</p>
+);
+
+const TitleSkeleton = () => (
+  <div className="h-[1.3rem] w-[8rem] bg-black-400"></div>
+);
+
+const PageSkeleton = () => (
+  <div className="flex w-full animate-pulse flex-col gap-[1rem] py-[2rem]">
+    <div className="h-[1.3rem] w-[6rem] bg-black-400"></div>
+    <div className="flex items-center gap-[1rem]">
+      <div className="h-[3.2rem] w-[3.2rem] rounded-full bg-black-400"></div>
+      <div className="h-[1.3rem] w-[8rem] bg-black-400"></div>
+    </div>
+    <div className="h-[1.8rem] w-[60%] bg-black-400"></div>
+    <div className="h-[18rem] w-full bg-black-400"></div>
+  </div>
 );

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import Loading from '@/ui/Base/Loading';
+
+export default function RootLoading() {
+  return <Loading fullpage />;
+}

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import { ReactNode, Suspense } from 'react';
 import { RecoilRoot } from 'recoil';
-import { ErrorBoundary } from 'react-error-boundary';
-
-import ErrorPage from '@/app/error';
-import ReactQueryProvider from '@/components/ReactQueryProvider';
-import ChakraThemeProvider from '@/components/ChakraThemeProvider';
 import Layout from '@/ui/common/Layout';
-import Loading from '@/ui/Base/Loading';
+import { ErrorBoundary } from 'react-error-boundary';
+import ChakraThemeProvider from '@/components/ChakraThemeProvider';
+import ReactQueryProvider from '@/components/ReactQueryProvider';
+import { ReactNode } from 'react';
+import ErrorPage from '@/app/error';
 import ToastProvider from '@/ui/Base/Toast/ToastProvider';
 
 const ContextProvider = ({ children }: { children: ReactNode }) => {
@@ -19,9 +17,7 @@ const ContextProvider = ({ children }: { children: ReactNode }) => {
           <ChakraThemeProvider>
             <ErrorBoundary fallbackRender={ErrorPage}>
               <ToastProvider>
-                <Suspense fallback={<Loading fullpage />}>
-                  <Layout>{children}</Layout>
-                </Suspense>
+                <Layout>{children}</Layout>
               </ToastProvider>
             </ErrorBoundary>
           </ChakraThemeProvider>

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { ReactNode, Suspense } from 'react';
 import { RecoilRoot } from 'recoil';
-import Layout from '@/ui/common/Layout';
 import { ErrorBoundary } from 'react-error-boundary';
-import ChakraThemeProvider from '@/components/ChakraThemeProvider';
-import ReactQueryProvider from '@/components/ReactQueryProvider';
-import { ReactNode } from 'react';
+
 import ErrorPage from '@/app/error';
+import ReactQueryProvider from '@/components/ReactQueryProvider';
+import ChakraThemeProvider from '@/components/ChakraThemeProvider';
+import Layout from '@/ui/common/Layout';
+import Loading from '@/ui/Base/Loading';
 import ToastProvider from '@/ui/Base/Toast/ToastProvider';
 
 const ContextProvider = ({ children }: { children: ReactNode }) => {
@@ -17,7 +19,9 @@ const ContextProvider = ({ children }: { children: ReactNode }) => {
           <ChakraThemeProvider>
             <ErrorBoundary fallbackRender={ErrorPage}>
               <ToastProvider>
-                <Layout>{children}</Layout>
+                <Suspense fallback={<Loading fullpage />}>
+                  <Layout>{children}</Layout>
+                </Suspense>
               </ToastProvider>
             </ErrorBoundary>
           </ChakraThemeProvider>

--- a/src/components/SSRSafeSuspense.tsx
+++ b/src/components/SSRSafeSuspense.tsx
@@ -1,0 +1,15 @@
+import { ComponentPropsWithoutRef, Suspense } from 'react';
+
+import useMounted from '@/hooks/useMounted';
+
+const SSRSafeSuspense = (props: ComponentPropsWithoutRef<typeof Suspense>) => {
+  const isMounted = useMounted();
+
+  if (isMounted) {
+    return <Suspense {...props} />;
+  }
+
+  return <>{props.fallback}</>;
+};
+
+export default SSRSafeSuspense;

--- a/src/queries/book/useBookInfoQuery.ts
+++ b/src/queries/book/useBookInfoQuery.ts
@@ -1,16 +1,14 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query';
-
+import type { APIBook, APIBookDetail } from '@/types/book';
+import useQueryWithSuspense, {
+  UseQueryOptionWithoutSuspense,
+} from '@/hooks/useQueryWithSuspense';
 import bookAPI from '@/apis/book';
-import type { APIBook } from '@/types/book';
 
 const useBookInfoQuery = (
   bookId: APIBook['bookId'],
-  options?: Pick<
-    UseQueryOptions<Awaited<ReturnType<typeof bookAPI.getBookInfo>>['data']>,
-    'onSuccess' | 'onError'
-  >
+  options?: UseQueryOptionWithoutSuspense<APIBookDetail>
 ) =>
-  useQuery(
+  useQueryWithSuspense(
     ['bookInfo', bookId],
     () => bookAPI.getBookInfo(bookId).then(({ data }) => data),
     options

--- a/src/queries/group/useBookGroupCommentsQuery.ts
+++ b/src/queries/group/useBookGroupCommentsQuery.ts
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
-import { QueryOptions } from '@/types/query';
 import {
   APIGroupCommentPagination,
   APIGroupDetail,
@@ -8,6 +6,9 @@ import {
 
 import GroupAPI from '@/apis/group';
 import bookGroupKeys from './key';
+import useQueryWithSuspense, {
+  UseQueryOptionWithoutSuspense,
+} from '@/hooks/useQueryWithSuspense';
 
 const transformComments = ({ bookGroupComments }: APIGroupCommentPagination) =>
   bookGroupComments.map<BookGroupComment>(comment => ({
@@ -23,18 +24,24 @@ const transformComments = ({ bookGroupComments }: APIGroupCommentPagination) =>
 
 const useBookGroupCommentsQuery = <TData = APIGroupCommentPagination>(
   groupId: APIGroupDetail['bookGroupId'],
-  select?: QueryOptions<APIGroupCommentPagination, TData>['select']
+  options?: UseQueryOptionWithoutSuspense<
+    APIGroupCommentPagination,
+    unknown,
+    TData
+  >
 ) =>
-  useQuery({
-    queryKey: bookGroupKeys.comments(groupId),
-    queryFn: () =>
+  useQueryWithSuspense(
+    bookGroupKeys.comments(groupId),
+    () =>
       GroupAPI.getGroupComments({ bookGroupId: groupId }).then(
         ({ data }) => data
       ),
-    select,
-  });
+    options
+  );
 
 export default useBookGroupCommentsQuery;
 
 export const useBookGroupComments = (groupId: APIGroupDetail['bookGroupId']) =>
-  useBookGroupCommentsQuery(groupId, transformComments);
+  useBookGroupCommentsQuery(groupId, {
+    select: transformComments,
+  });

--- a/src/queries/group/useBookGroupQuery.ts
+++ b/src/queries/group/useBookGroupQuery.ts
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryOptions } from '@tanstack/react-query';
 
 import { APIGroupDetail, BookGroupDetail } from '@/types/group';
-import { QueryOptions } from '@/types/query';
 
+import useQueryWithSuspense from '@/hooks/useQueryWithSuspense';
 import GroupAPI from '@/apis/group';
 import bookGroupKeys from './key';
 
@@ -20,21 +20,23 @@ const transformBookGroupDetail = (data: APIGroupDetail) =>
 
 export const useBookGroupQuery = <TData = APIGroupDetail>(
   groupId: APIGroupDetail['bookGroupId'],
-  select: QueryOptions<APIGroupDetail, TData>['select']
+  options?: UseQueryOptions<APIGroupDetail, unknown, TData>
 ) =>
-  useQuery({
-    queryKey: bookGroupKeys.detail(groupId),
-    queryFn: () =>
+  useQueryWithSuspense(
+    bookGroupKeys.detail(groupId),
+    () =>
       GroupAPI.getGroupDetailInfo({ bookGroupId: groupId }).then(
         ({ data }) => data
       ),
-    select,
-  });
+    options
+  );
 
 export default useBookGroupQuery;
 
 export const useBookGroup = (groupId: APIGroupDetail['bookGroupId']) =>
-  useBookGroupQuery(groupId, transformBookGroupDetail);
+  useBookGroupQuery(groupId, {
+    select: transformBookGroupDetail,
+  });
 
 export const useBookGroupTitle = (groupId: APIGroupDetail['bookGroupId']) =>
-  useBookGroupQuery(groupId, data => data.title);
+  useBookGroupQuery(groupId, { select: data => data.title });

--- a/src/queries/group/useBookGroupQuery.ts
+++ b/src/queries/group/useBookGroupQuery.ts
@@ -1,9 +1,10 @@
 import { UseQueryOptions } from '@tanstack/react-query';
 
 import { APIGroupDetail, BookGroupDetail } from '@/types/group';
-
-import useQueryWithSuspense from '@/hooks/useQueryWithSuspense';
+import { isExpired } from '@/utils/date';
 import GroupAPI from '@/apis/group';
+import useQueryWithSuspense from '@/hooks/useQueryWithSuspense';
+
 import bookGroupKeys from './key';
 
 const transformBookGroupDetail = (data: APIGroupDetail) =>
@@ -40,3 +41,18 @@ export const useBookGroup = (groupId: APIGroupDetail['bookGroupId']) =>
 
 export const useBookGroupTitle = (groupId: APIGroupDetail['bookGroupId']) =>
   useBookGroupQuery(groupId, { select: data => data.title });
+
+export const useBookGroupOwner = (groupId: APIGroupDetail['bookGroupId']) =>
+  useBookGroupQuery(groupId, {
+    select: data => ({ isMe: data.isOwner, id: data.owner.id }),
+  });
+
+export const useBookGroupJoinInfo = (groupId: APIGroupDetail['bookGroupId']) =>
+  useBookGroupQuery(groupId, {
+    select: data => ({
+      isExpired: isExpired(data.endDate),
+      isMember: data.isGroupMember,
+      hasPassword: data.hasJoinPasswd,
+      question: data.joinQuestion,
+    }),
+  });

--- a/src/queries/user/useMyProfileQuery.ts
+++ b/src/queries/user/useMyProfileQuery.ts
@@ -5,11 +5,20 @@ import useQueryWithSuspense, {
 } from '@/hooks/useQueryWithSuspense';
 import userKeys from './key';
 
-const useMyProfileQuery = (options?: UseQueryOptionWithoutSuspense<APIUser>) =>
+const useMyProfileQuery = <TData = APIUser>(
+  options?: UseQueryOptionWithoutSuspense<APIUser, unknown, TData>
+) =>
   useQueryWithSuspense(
     userKeys.me(),
     () => userAPI.getMyProfile().then(({ data }) => data),
-    options
+    { ...options, staleTime: Infinity }
   );
 
 export default useMyProfileQuery;
+
+export const useMyProfileId = (
+  options?: Omit<
+    UseQueryOptionWithoutSuspense<APIUser, unknown, unknown>,
+    'select'
+  >
+) => useMyProfileQuery({ ...options, select: data => data.userId });

--- a/src/stories/Base/Loading.stories.tsx
+++ b/src/stories/Base/Loading.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Loading from '@/ui/Base/Loading';
+
+const meta: Meta<typeof Loading> = {
+  title: 'Base/Loading',
+  component: Loading,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Loading>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Main: Story = {
+  args: { color: 'main' },
+};
+
+export const Grey: Story = {
+  args: { color: 'grey' },
+};

--- a/src/ui/Base/Avatar.tsx
+++ b/src/ui/Base/Avatar.tsx
@@ -10,23 +10,23 @@ interface AvatarProps {
 
 const FALLBACK_IMAGE_SRC = '/icons/avatar.svg';
 
-const getSizeClasses = (size: AvatarSize) => {
+const getAvatarSize = (size: AvatarSize) => {
   switch (size) {
     case 'small': {
-      return 'w-[2rem] h-[2rem]';
+      return ['w-[2rem] h-[2rem]', { width: 20, height: 20 }] as const;
     }
     case 'medium': {
-      return 'w-[3.2rem] h-[3.2rem]';
+      return ['w-[3.2rem] h-[3.2rem]', { width: 32, height: 32 }] as const;
     }
     case 'large': {
-      return 'w-[7rem] h-[7rem]';
+      return ['w-[7rem] h-[7rem]', { width: 70, height: 70 }] as const;
     }
   }
 };
 
 const Avatar = ({ name, src, size = 'medium' }: AvatarProps) => {
   const [image, setImage] = useState(src ?? FALLBACK_IMAGE_SRC);
-  const sizeClass = getSizeClasses(size);
+  const [sizeClass, sizeProps] = getAvatarSize(size);
 
   const setFallbackImage = () => setImage(FALLBACK_IMAGE_SRC);
 
@@ -37,8 +37,8 @@ const Avatar = ({ name, src, size = 'medium' }: AvatarProps) => {
       <Image
         alt={name || 'avatar'}
         src={image}
-        fill
-        className={`rounded-full object-cover ${sizeClass}`}
+        className={`h-full w-full rounded-full object-cover`}
+        {...sizeProps}
         onError={setFallbackImage}
       />
     </span>

--- a/src/ui/Base/Avatar.tsx
+++ b/src/ui/Base/Avatar.tsx
@@ -1,14 +1,14 @@
+import { useState } from 'react';
 import Image from 'next/image';
 
-import { IconAvatar } from '@public/icons';
-
 type AvatarSize = 'small' | 'medium' | 'large';
-
 interface AvatarProps {
   name?: string;
   src?: string;
   size?: AvatarSize;
 }
+
+const FALLBACK_IMAGE_SRC = '/icons/avatar.svg';
 
 const getSizeClasses = (size: AvatarSize) => {
   switch (size) {
@@ -25,22 +25,22 @@ const getSizeClasses = (size: AvatarSize) => {
 };
 
 const Avatar = ({ name, src, size = 'medium' }: AvatarProps) => {
+  const [image, setImage] = useState(src ?? FALLBACK_IMAGE_SRC);
   const sizeClass = getSizeClasses(size);
+
+  const setFallbackImage = () => setImage(FALLBACK_IMAGE_SRC);
 
   return (
     <span
       className={`relative inline-block rounded-full bg-white ${sizeClass}`}
     >
-      {src ? (
-        <Image
-          alt={name || 'avatar'}
-          src={src}
-          fill
-          className={`rounded-full object-cover ${sizeClass}`}
-        />
-      ) : (
-        <IconAvatar />
-      )}
+      <Image
+        alt={name || 'avatar'}
+        src={image}
+        fill
+        className={`rounded-full object-cover ${sizeClass}`}
+        onError={setFallbackImage}
+      />
     </span>
   );
 };

--- a/src/ui/Base/BottomActionButton.tsx
+++ b/src/ui/Base/BottomActionButton.tsx
@@ -2,7 +2,7 @@ import { ComponentPropsWithoutRef } from 'react';
 import Button from './Button';
 
 type BottomActionButtonProps = Omit<
-  ComponentPropsWithoutRef<'button'>,
+  ComponentPropsWithoutRef<typeof Button>,
   'className'
 >;
 
@@ -11,7 +11,7 @@ const BottomActionButton = ({
   ...props
 }: BottomActionButtonProps) => {
   return (
-    <div className="fixed bottom-0 left-0 z-10 w-full bg-white px-[2.0rem] py-[1.5rem]">
+    <div className="absolute bottom-0 left-0 z-10 w-full bg-white px-[2.0rem] py-[1.5rem]">
       <Button size="full" {...props}>
         {children}
       </Button>

--- a/src/ui/Base/Loading.tsx
+++ b/src/ui/Base/Loading.tsx
@@ -1,0 +1,55 @@
+import Portal from './Portal';
+
+const schemes = {
+  main: 'bg-main-900',
+  grey: 'bg-black-400',
+} as const;
+
+type DotScheme = keyof typeof schemes;
+
+interface LoadingProps {
+  color?: DotScheme;
+  fullpage?: boolean;
+}
+
+const Loading = ({ color = 'main', fullpage = false }: LoadingProps) => {
+  if (fullpage) {
+    return (
+      <Portal id="loading">
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+          <LoadingDots color={color} />
+        </div>
+      </Portal>
+    );
+  }
+
+  return <LoadingDots color={color} />;
+};
+
+export default Loading;
+
+const LoadingDots = ({ color }: { color: DotScheme }) => (
+  <div className="flex gap-[1rem]">
+    <LoadingDot color={color} animationStep={0} />
+    <LoadingDot color={color} animationStep={1} />
+    <LoadingDot color={color} animationStep={2} />
+  </div>
+);
+
+const animations = {
+  0: 'animate-dot-flash',
+  1: 'animate-dot-flash-delay-0.5',
+  2: 'animate-dot-flash-delay-1',
+} as const;
+
+export const LoadingDot = ({
+  color,
+  animationStep = 0,
+}: {
+  color: DotScheme;
+  animationStep?: keyof typeof animations;
+}) => (
+  <span
+    className={`h-[1rem] w-[1rem] rounded-full ${schemes[color]} ${animations[animationStep]}`}
+  ></span>
+);

--- a/src/ui/Base/Loading.tsx
+++ b/src/ui/Base/Loading.tsx
@@ -1,5 +1,3 @@
-import Portal from './Portal';
-
 const schemes = {
   main: 'bg-main-900',
   grey: 'bg-black-400',
@@ -15,11 +13,9 @@ interface LoadingProps {
 const Loading = ({ color = 'main', fullpage = false }: LoadingProps) => {
   if (fullpage) {
     return (
-      <Portal id="loading">
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-          <LoadingDots color={color} />
-        </div>
-      </Portal>
+      <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <LoadingDots color={color} />
+      </div>
     );
   }
 

--- a/src/ui/Base/Toast/ToastProvider.tsx
+++ b/src/ui/Base/Toast/ToastProvider.tsx
@@ -40,7 +40,7 @@ const ToastProvider = ({ children }: { children?: ReactNode }) => {
       {children}
       <Portal id="toast">
         <div
-          className={`fixed bottom-[1.5rem] left-[1.5rem] right-[1.5rem] w-[43rem] max-w-[calc(100%-3rem)] translate-y-[300%] ${animations[animation]}`}
+          className={`fixed bottom-[1.5rem] w-full max-w-[43rem] translate-y-[300%] ${animations[animation]} z-20 m-auto px-[1.5rem]`}
         >
           {toast && <ToastItem type={toast.type} message={toast.message} />}
         </div>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,3 +3,7 @@ export const toDayFromMillseconds = (value: number) =>
 
 export const getDdayCount = (target: Date) =>
   toDayFromMillseconds(target.getTime() - new Date().getTime());
+
+export const isExpired = (end: string) => {
+  return getDdayCount(new Date(end)) < 0;
+};

--- a/src/v1/book/BookCover.tsx
+++ b/src/v1/book/BookCover.tsx
@@ -18,31 +18,31 @@ type BookCoverProps = Required<
   size?: BookCoverSize;
 };
 
-const getCoverSizeClasses = (size: BookCoverSize) => {
+const getCoverSize = (size: BookCoverSize) => {
   switch (size) {
     case 'xsmall': {
-      return 'w-[6.5rem] h-[9.1rem]';
+      return ['w-[6.5rem] h-[9.1rem]', { width: 65, height: 91 }] as const;
     }
     case 'small': {
-      return 'w-[7.0rem] h-[9.8rem]';
+      return ['w-[7.0rem] h-[9.8rem]', { width: 70, height: 98 }] as const;
     }
     case 'medium': {
-      return 'w-[7.5rem] h-[10.5rem]';
+      return ['w-[7.5rem] h-[10.5rem]', { width: 75, height: 105 }] as const;
     }
     case 'large': {
-      return 'w-[9.0rem] h-[12.6rem]';
+      return ['w-[9.0rem] h-[12.6rem]', { width: 90, height: 126 }] as const;
     }
     case 'xlarge': {
-      return 'w-[11.0rem] h-[15.4rem]';
+      return ['w-[11.0rem] h-[15.4rem]', { width: 110, height: 154 }] as const;
     }
     case '2xlarge': {
-      return 'w-[18.0rem] h-[25.2rem]';
+      return ['w-[18.0rem] h-[25.2rem]', { width: 180, height: 252 }] as const;
     }
   }
 };
 
 const BookCover = ({ src, title, size = 'medium' }: BookCoverProps) => {
-  const sizeClasses = getCoverSizeClasses(size);
+  const [sizeClasses, sizeProps] = getCoverSize(size);
 
   return (
     <div className={`relative flex-shrink-0 ${sizeClasses}`}>
@@ -51,8 +51,8 @@ const BookCover = ({ src, title, size = 'medium' }: BookCoverProps) => {
         alt={title || 'book-cover'}
         placeholder="blur"
         blurDataURL={DATA_URL['placeholder']}
-        className="object-fit rounded-[0.5rem] shadow-bookcover"
-        fill
+        className={`object-fit h-full w-full rounded-[0.5rem] shadow-bookcover`}
+        {...sizeProps}
       />
     </div>
   );

--- a/src/v1/bookGroup/BookGroupNavigation.tsx
+++ b/src/v1/bookGroup/BookGroupNavigation.tsx
@@ -1,0 +1,90 @@
+import {
+  ReactNode,
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+} from 'react';
+import { useRouter } from 'next/navigation';
+
+import TopNavigation from '@/ui/Base/TopNavigation';
+import { IconArrowLeft, IconHamburger, IconPost } from '@public/icons';
+import {
+  useBookGroupOwner,
+  useBookGroupTitle,
+  useBookGroupJoinInfo,
+} from '@/queries/group/useBookGroupQuery';
+
+const NavigationContext = createContext({} as { groupId: number });
+
+const getTargetChildren = (children: ReactNode, Target: () => JSX.Element) => {
+  const childrenArray = Children.toArray(children);
+
+  return childrenArray.filter(
+    child => isValidElement(child) && child.type === (<Target />).type
+  );
+};
+
+const BookGroupNavigation = ({
+  groupId,
+  children,
+}: {
+  groupId: number;
+  children: ReactNode;
+}) => {
+  return (
+    <NavigationContext.Provider value={{ groupId }}>
+      <TopNavigation>
+        <TopNavigation.LeftItem>
+          {getTargetChildren(children, BackButton)}
+        </TopNavigation.LeftItem>
+        <TopNavigation.CenterItem textAlign="left">
+          {getTargetChildren(children, Title)}
+        </TopNavigation.CenterItem>
+        <TopNavigation.RightItem>
+          {getTargetChildren(children, WriteButton)}
+          {getTargetChildren(children, MenuButton)}
+        </TopNavigation.RightItem>
+      </TopNavigation>
+    </NavigationContext.Provider>
+  );
+};
+
+const BackButton = () => {
+  const router = useRouter();
+
+  return (
+    <a onClick={router.back}>
+      <IconArrowLeft />
+    </a>
+  );
+};
+
+const Title = () => {
+  const { groupId } = useContext(NavigationContext);
+  const { data: title } = useBookGroupTitle(groupId);
+
+  return <p className="w-[90%] truncate">{title}</p>;
+};
+
+const MenuButton = () => {
+  const { groupId } = useContext(NavigationContext);
+  const { data: owner } = useBookGroupOwner(groupId);
+
+  return <>{owner.isMe && <IconHamburger />}</>;
+};
+
+const WriteButton = () => {
+  const { groupId } = useContext(NavigationContext);
+  const { data: joinInfo } = useBookGroupJoinInfo(groupId);
+  const { isMember } = joinInfo;
+
+  return <>{isMember && <IconPost />}</>;
+};
+
+BookGroupNavigation.BackButton = BackButton;
+BookGroupNavigation.Title = Title;
+BookGroupNavigation.MenuButton = MenuButton;
+BookGroupNavigation.WriteButton = WriteButton;
+
+export default BookGroupNavigation;

--- a/src/v1/bookGroup/detail/BookGroupInfo.tsx
+++ b/src/v1/bookGroup/detail/BookGroupInfo.tsx
@@ -13,34 +13,27 @@ const BookGroupInfo = ({ groupId }: { groupId: number }) => {
 
   return (
     <div className="flex flex-col gap-[1rem] py-[2rem]">
-      {bookGroupInfo && (
-        <>
-          <div className="flex gap-[0.5rem]">
-            <BookGroupStatus
-              start={bookGroupInfo.date.start}
-              end={bookGroupInfo.date.end}
-            />
-            <Public isPublic={bookGroupInfo.isPublic} />
-          </div>
-          <Owner
-            userId={bookGroupInfo.owner.id}
-            isMe={bookGroupInfo.owner.isMe}
-          />
-          <Title title={bookGroupInfo.title} />
-          <BookInfoCard bookId={bookGroupInfo.bookId} />
-          <div className="flex flex-col gap-[0.3rem]">
-            <Duration
-              start={bookGroupInfo.date.start}
-              end={bookGroupInfo.date.end}
-            />
-            <MemberCapacity
-              current={bookGroupInfo.memberCount.current}
-              max={bookGroupInfo.memberCount.max}
-            />
-          </div>
-          <Description content={bookGroupInfo.description} />
-        </>
-      )}
+      <div className="flex gap-[0.5rem]">
+        <BookGroupStatus
+          start={bookGroupInfo.date.start}
+          end={bookGroupInfo.date.end}
+        />
+        <Public isPublic={bookGroupInfo.isPublic} />
+      </div>
+      <Owner userId={bookGroupInfo.owner.id} isMe={bookGroupInfo.owner.isMe} />
+      <Title title={bookGroupInfo.title} />
+      <BookInfoCard bookId={bookGroupInfo.bookId} />
+      <div className="flex flex-col gap-[0.3rem]">
+        <Duration
+          start={bookGroupInfo.date.start}
+          end={bookGroupInfo.date.end}
+        />
+        <MemberCapacity
+          current={bookGroupInfo.memberCount.current}
+          max={bookGroupInfo.memberCount.max}
+        />
+      </div>
+      <Description content={bookGroupInfo.description} />
     </div>
   );
 };
@@ -62,18 +55,15 @@ const Owner = ({
 
   return (
     <div className="flex items-center gap-[1rem]">
-      {userInfo && (
-        <>
-          <Avatar
-            name={userInfo.nickname}
-            size="medium"
-            src={userInfo.profileImage}
-          />
-          <span className="text-center text-sm font-bold">
-            {userInfo.nickname} {isMe && ' 👑'}
-          </span>
-        </>
-      )}
+      <Avatar
+        name={userInfo.nickname}
+        size="medium"
+        src={userInfo.profileImage}
+      />
+      <span className="text-center text-sm font-bold">
+        <span>{userInfo.nickname}</span>
+        <span>{isMe && ' 👑'}</span>
+      </span>
     </div>
   );
 };
@@ -86,22 +76,14 @@ const BookInfoCard = ({ bookId }: { bookId: number }) => {
   const { data: bookInfo } = useBookInfoQuery(bookId);
 
   return (
-    <div className="flex min-h-[10rem] w-full cursor-pointer gap-[2.4rem] rounded-[0.5rem] border-[0.05rem] border-cancel px-[2.2rem] py-[1.8rem]">
-      {bookInfo && (
-        <>
-          <BookCover
-            size="xsmall"
-            src={bookInfo.imageUrl}
-            title={bookInfo.title}
-          />
-          <div className="flex min-w-0 flex-grow flex-col">
-            <span className="truncate text-sm font-bold">{bookInfo.title}</span>
-            <span className="text-xs text-placeholder">{bookInfo.author}</span>
-          </div>
-          {/** 왼쪽 방향의 화살표를 180도 회전하여 사용 */}
-          <IconArrowLeft className="h-[1.5rem] w-[1.5rem] flex-shrink-0 rotate-180" />
-        </>
-      )}
+    <div className="flex min-h-[11rem] w-full cursor-pointer gap-[2.4rem] rounded-[0.5rem] border-[0.05rem] border-cancel px-[2.2rem] py-[1.8rem]">
+      <BookCover size="xsmall" src={bookInfo.imageUrl} title={bookInfo.title} />
+      <div className="flex min-w-0 flex-grow flex-col">
+        <span className="truncate text-sm font-bold">{bookInfo.title}</span>
+        <span className="text-xs text-placeholder">{bookInfo.author}</span>
+      </div>
+      {/** 왼쪽 방향의 화살표를 180도 회전하여 사용 */}
+      <IconArrowLeft className="h-[1.5rem] w-[1.5rem] flex-shrink-0 rotate-180" />
     </div>
   );
 };

--- a/src/v1/bookGroup/detail/CommentList.tsx
+++ b/src/v1/bookGroup/detail/CommentList.tsx
@@ -1,9 +1,12 @@
 import { IconHamburger } from '@public/icons';
 import Avatar from '@/ui/Base/Avatar';
 import { useBookGroupComments } from '@/queries/group/useBookGroupCommentsQuery';
+import { useMyProfileId } from '@/queries/user/useMyProfileQuery';
+import { isAuthed } from '@/utils/helpers';
 
 const CommentList = ({ groupId }: { groupId: number }) => {
   const { data: comments } = useBookGroupComments(groupId);
+  const { data: myId } = useMyProfileId({ enabled: isAuthed() });
 
   return (
     <div className="flex flex-col gap-[1rem]">
@@ -20,7 +23,7 @@ const CommentList = ({ groupId }: { groupId: number }) => {
                 <Name name={writer.name} />
                 <Date date={createdAt} />
               </div>
-              <MenuButton />
+              {writer.id === myId && <MenuButton />}
             </div>
             <Comment content={content} />
             <Divider />
@@ -52,4 +55,4 @@ const Comment = ({ content }: { content: string }) => (
   <p className="text-justify text-md">{content}</p>
 );
 
-const Divider = () => <p className=" border-b-black100 border-[0.05rem]"></p>;
+const Divider = () => <p className=" border-[0.05rem] border-b-[#eaf1fa]"></p>;

--- a/src/v1/bookGroup/detail/CommentList.tsx
+++ b/src/v1/bookGroup/detail/CommentList.tsx
@@ -3,38 +3,51 @@ import Avatar from '@/ui/Base/Avatar';
 import { useBookGroupComments } from '@/queries/group/useBookGroupCommentsQuery';
 import { useMyProfileId } from '@/queries/user/useMyProfileQuery';
 import { isAuthed } from '@/utils/helpers';
+import { useBookGroup } from '@/queries/group/useBookGroupQuery';
 
 const CommentList = ({ groupId }: { groupId: number }) => {
+  const { data: bookGroupInfo } = useBookGroup(groupId);
   const { data: comments } = useBookGroupComments(groupId);
   const { data: myId } = useMyProfileId({ enabled: isAuthed() });
+  const { isPublic } = bookGroupInfo;
+
+  if (!isPublic) {
+    return (
+      <p className="py-[2rem] text-center text-sm">
+        {`멤버만 볼 수 있어요 🥲`}
+      </p>
+    );
+  }
+
+  if (comments.length === 0) {
+    return (
+      <p className="self-center whitespace-pre-line py-[2rem] text-center text-sm">
+        {`아직 게시글이 없어요.
+          가장 먼저 게시글을 남겨보세요!`}
+      </p>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-[1rem]">
-      {comments.length ? (
-        comments.map(({ id, writer, createdAt, content }) => (
-          <div className="flex flex-col gap-[1.7rem] pt-[1rem]" key={id}>
-            <div className="flex gap-[1rem]">
-              <Avatar
-                src={writer.profileImageSrc}
-                name={writer.name}
-                size="medium"
-              />
-              <div className="flex flex-grow flex-col">
-                <Name name={writer.name} />
-                <Date date={createdAt} />
-              </div>
-              {writer.id === myId && <MenuButton />}
+      {comments.map(({ id, writer, createdAt, content }) => (
+        <div className="flex flex-col gap-[1.7rem] pt-[1rem]" key={id}>
+          <div className="flex gap-[1rem]">
+            <Avatar
+              src={writer.profileImageSrc}
+              name={writer.name}
+              size="medium"
+            />
+            <div className="flex flex-grow flex-col">
+              <Name name={writer.name} />
+              <Date date={createdAt} />
             </div>
-            <Comment content={content} />
-            <Divider />
+            {writer.id === myId && <MenuButton />}
           </div>
-        ))
-      ) : (
-        <p className="self-center whitespace-pre-line py-[2rem] text-center text-sm">
-          {`아직 게시글이 없어요.
-          가장 먼저 게시글을 남겨보세요!`}
-        </p>
-      )}
+          <Comment content={content} />
+          <Divider />
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/v1/bookGroup/detail/CommentList.tsx
+++ b/src/v1/bookGroup/detail/CommentList.tsx
@@ -10,7 +10,7 @@ const CommentList = ({ groupId }: { groupId: number }) => {
 
   return (
     <div className="flex flex-col gap-[1rem]">
-      {comments &&
+      {comments.length ? (
         comments.map(({ id, writer, createdAt, content }) => (
           <div className="flex flex-col gap-[1.7rem] pt-[1rem]" key={id}>
             <div className="flex gap-[1rem]">
@@ -28,7 +28,13 @@ const CommentList = ({ groupId }: { groupId: number }) => {
             <Comment content={content} />
             <Divider />
           </div>
-        ))}
+        ))
+      ) : (
+        <p className="self-center whitespace-pre-line py-[2rem] text-center text-sm">
+          {`아직 게시글이 없어요.
+          가장 먼저 게시글을 남겨보세요!`}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/v1/bookGroup/detail/JoinBookGroupButton.tsx
+++ b/src/v1/bookGroup/detail/JoinBookGroupButton.tsx
@@ -9,8 +9,8 @@ import useToast from '@/ui/Base/Toast/useToast';
 import BottomActionButton from '@/ui/Base/BottomActionButton';
 
 const JoinBookGroupButton = ({ groupId }: { groupId: number }) => {
-  const router = useRouter();
-  const pathname = usePathname();
+  const _router = useRouter();
+  const _pathname = usePathname();
   const toast = useToast();
 
   const {
@@ -38,7 +38,8 @@ const JoinBookGroupButton = ({ groupId }: { groupId: number }) => {
 
   const handleButtonClick = async () => {
     if (hasPassword) {
-      router.push(`${pathname}/join`);
+      // TODO: 모임 가입문제 페이지 생성 후 연결
+      // router.push(`${pathname}/join`);
       return;
     }
 

--- a/src/v1/bookGroup/detail/JoinBookGroupButton.tsx
+++ b/src/v1/bookGroup/detail/JoinBookGroupButton.tsx
@@ -1,0 +1,67 @@
+import { usePathname, useRouter } from 'next/navigation';
+
+import { SERVICE_ERROR_MESSAGE } from '@/constants';
+import { isAxiosErrorWithCustomCode } from '@/utils/helpers';
+
+import { useBookGroupJoinInfo } from '@/queries/group/useBookGroupQuery';
+import groupAPI from '@/apis/group';
+import useToast from '@/ui/Base/Toast/useToast';
+import BottomActionButton from '@/ui/Base/BottomActionButton';
+
+const JoinBookGroupButton = ({ groupId }: { groupId: number }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const toast = useToast();
+
+  const {
+    data: { isExpired, isMember, hasPassword },
+    refetch,
+  } = useBookGroupJoinInfo(groupId);
+
+  const joinBookGroup = async () => {
+    try {
+      await groupAPI.joinGroup({ bookGroupId: groupId });
+      toast.show({ message: '모임에 가입했어요!', type: 'success' });
+      refetch();
+    } catch (error) {
+      if (!isAxiosErrorWithCustomCode(error)) {
+        toast.show({ message: '잠시 후 다시 시도해주세요.', type: 'error' });
+        return;
+      }
+
+      const { code } = error.response.data;
+      const message = SERVICE_ERROR_MESSAGE[code];
+
+      toast.show({ message, type: 'error' });
+    }
+  };
+
+  const handleButtonClick = async () => {
+    if (hasPassword) {
+      router.push(`${pathname}/join`);
+      return;
+    }
+
+    joinBookGroup();
+  };
+
+  if (isMember) {
+    return null;
+  }
+
+  if (isExpired) {
+    return (
+      <BottomActionButton colorScheme="grey" disabled>
+        모임이 종료되었어요.
+      </BottomActionButton>
+    );
+  }
+
+  return (
+    <BottomActionButton onClick={handleButtonClick}>
+      참여하기
+    </BottomActionButton>
+  );
+};
+
+export default JoinBookGroupButton;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,12 +94,25 @@ module.exports = {
           from: { transform: 'translateY(300%)' },
           to: { transform: 'translateY(300%)' },
         },
+        'dot-flash': {
+          '0%': {
+            opacity: 1,
+            transform: 'translateY(0px)',
+          },
+          '50%,100%': {
+            opacity: 0.2,
+            transform: 'translateY(5px)',
+          },
+        },
       },
       animation: {
         'page-transition': 'page-transition 0.2s forwards ease-in-out',
         'slide-in': '0.3s forwards slide-in ease-in-out',
         'slide-out': '0.3s forwards slide-out ease-in-out',
         'slide-init': '0.3s forwards slide-init ease-in-out',
+        'dot-flash': '1s infinite dot-flash alternate',
+        'dot-flash-delay-0.5': '1s 0.5s infinite dot-flash alternate',
+        'dot-flash-delay-1': '1s 1s infinite dot-flash alternate',
       },
     },
   },


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

### Avatar
- 기본 아바타 아이콘 디자인이 어색해보여 수정했어요.
- Avatar 컴포넌트의 fallback 이미지를 설정했어요.
	- 올바르지 않은 이미지 링크가 응답으로 와서 (아마 해당 사용자가 카카오톡 프로필사진을 바꿔서 그런 것 같아요..) 이미지가 깨지는 경우, fallback 이미지가 렌더링돼요!

### Loading 컴포넌트 구현
- 모임 상세페이지를 작업하면서 적절한 로딩 컴포넌트가 있으면 좋겠다고 생각해서 구현해봤어요. 자유롭게 의견 남겨주세요! 😀 (스토리북으로 확인해주세요!)
![로딩컴포넌트](https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/290ffd81-8fa6-4f8d-ab23-61b14a9bca7f)

### 스켈레톤 UI 구현
- 모임 상세페이지에 스켈레톤 UI를 적용했어요! 피드백 남겨주세요! 🫢

### Suspense 적용
- 모임 상세페이지에서 사용되는 Query들에 모두 Suspense 옵션을 적용했어요.
- Suspense 옵션을 적용하고 Suspense를 감싸지 않으면 무한으로 refetch 되는 이슈가 있어요. 그래서 최상위에 Suspense를 적용하기 위해 app 디렉토리 최상위 루트에 `loading.tsx` 를 추가했어요. [관련 Tanstack-Query 이슈](https://github.com/TanStack/query/issues/6116)
- 모임 상세 정보 조회 API는 사용자 인증이 필요하지 않은 API 예요. 그런데 로그인 상태에 따라 isMember, isOwner 등 응답의 일부가 일치하지 않아 서버에서 컴포넌트를 만드는 과정에서 하이드레이션 관련 오류가 발생했어요. 그래서 CSR 환경에서만 Suspense가 동작할 수 있도록 하는  `SSRSafeSusepnse`라는 Custom Suspense를 만들어 적용해봤어요.

### 모임 상세페이지 TopNavigation 컴포넌트 분리
- BookGroupNavigation 이름으로 합성 컴포넌트를 만들었어요.
- 처음에는 뒤로가기 버튼 등 기본적인 레이아웃은 빠르게 렌더링될 수 있도록 SSR로, 책 제목 부분에는 스켈레톤을 적용하고 싶어서 페이지단으로 끌어올린 후 Suspense를 적용했었어요. 이후 `groupId`를 공유하기 위해 합성 컴포넌트를 만드는 과정에서 `Title`이 Suspense로 인해 직접적인 자식이 아니게 되면서 groupId를 context에서 가져오지 못하는 상황이 발생했습니다.. 
- 뭔가를 더 하기엔 너무 멀리온 것 같고.. 이 부분은 사용자 경험을 높이기 위한 작업이니 나중에 더 고민해보고 리팩토링해보겠습니다!

```tsx
<BookGroupNavigation groupId={groupId}>
  <Suspense fallback={<TitleSkeleton />}>
    <BookGroupNavigation.Title />
  </Suspense>
</BookGroupNavigation>
```
### myProfileQuery
- `useMyProfileQuery`의 staleTime을 `Infinity`로 설정했어요.

### Avatar, BookCover next/image 경고 해결
- Avatar, BookCover 컴포넌트에서 `fill`과 `sizes` 속성을 함께 사용하지 않아 퍼포먼스 관련 워닝이 노출됐었는데, `width`, `height`를 정확히 prop으로 전달하는 방식으로 수정해서 해결했어요.

# 공유할 내용
### 📣 env 환경 변수를 업데이트 해주세요!
Suspense를 적용하면서 아래 에러 메세지를 만났어요. node 환경에서 http 요청을 보낼 때 host 정보가 명확하지 않으면 발생할 수 있는 에러라고 이해했어요. 그래서 axios에 `baseUrl`을 설정해서 해결했어요! production 환경에도 적용 부탁드립니다 민종님..🙏🏻 @minjongbaek 

```env
[ local ]
NEXT_HOST=http://local.dev.dadok.site:3000

[ production ]
NEXT_HOST=https://.dev.dadok.site
```
<img width="500" alt="스크린샷 2023-11-24 오전 1 51 09" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/7200808f-2f16-4b27-b292-a2f4b071e3a6">

# PR 포인트
<!-- - ex) XX를 중점적으로 봐주세요. -->
모임 상세 페이지를 구현하면서 발생하는 이슈들을 한번에 수정하다보니 file changed가 많아졌어요.. 죄송해요..🥹 다음부턴 우선순위를 고려해서 적절히 이슈 분할한 후 작업해보겠습니다..🙇🏻‍♀️

# 관련 이슈

- Close #447  <!--이슈번호-->
