### PR TITLE
[#470] Menu 컴포넌트

### DIFF
--- a/public/icons/hamburger.svg
+++ b/public/icons/hamburger.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 20 20" fill="black" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M9 9.5C9 8.67157 9.67157 8 10.5 8C11.3284 8 12 8.67157 12 9.5C12 10.3284 11.3284 11 10.5 11C9.67157 11 9 10.3284 9 9.5Z" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M9 3.5C9 2.67157 9.67157 2 10.5 2C11.3284 2 12 2.67157 12 3.5C12 4.32843 11.3284 5 10.5 5C9.67157 5 9 4.32843 9 3.5Z" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M9 15.5C9 14.6716 9.67157 14 10.5 14C11.3284 14 12 14.6716 12 15.5C12 16.3284 11.3284 17 10.5 17C9.67157 17 9 16.3284 9 15.5Z" fill="black"/>

--- a/src/stories/base/Menu.stories.tsx
+++ b/src/stories/base/Menu.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Menu from '@/v1/base/Menu';
+
+const meta: Meta<typeof Menu> = {
+  title: 'Base/Menu',
+  component: Menu,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Menu>;
+
+export const Dropdown: Story = {
+  render: () => {
+    return (
+      <div className="flex justify-end">
+        <Menu>
+          <Menu.Toggle />
+          <Menu.DropdownList>
+            <Menu.Item>수정하기</Menu.Item>
+            <Menu.Item>삭제하기</Menu.Item>
+          </Menu.DropdownList>
+        </Menu>
+      </div>
+    );
+  },
+};
+
+export const Bottomsheet: Story = {
+  render: () => {
+    return (
+      <Menu>
+        <Menu.Toggle />
+        <Menu.BottomSheetList>
+          <Menu.Item>수정하기</Menu.Item>
+          <Menu.Item>삭제하기</Menu.Item>
+        </Menu.BottomSheetList>
+      </Menu>
+    );
+  },
+};

--- a/src/v1/base/BottomSheet.tsx
+++ b/src/v1/base/BottomSheet.tsx
@@ -38,7 +38,7 @@ const BottomSheet = ({
                 leaveFrom="translate-y-0"
                 leaveTo="translate-y-full"
               >
-                <Dialog.Panel className="pointer-events-auto relative max-h-[100dvh] w-[43rem] rounded-t-[1.5rem] bg-white p-[2rem]">
+                <Dialog.Panel className="pointer-events-auto relative max-h-[100dvh] w-[43rem] rounded-t-[1.5rem] bg-white px-[1rem] py-[1.5rem]">
                   {children}
                 </Dialog.Panel>
               </Transition.Child>

--- a/src/v1/base/Menu.tsx
+++ b/src/v1/base/Menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  PropsWithChildren,
   createContext,
   useCallback,
   useContext,
@@ -11,16 +12,16 @@ import { IconHamburger } from '@public/icons';
 import BottomSheet from './BottomSheet';
 
 type MenuContextValue = {
-  open: boolean;
+  isOpen: boolean;
   toggle: () => void;
 };
 
 const MenuContext = createContext({} as MenuContextValue);
 
 const Menu = ({ children }: { children?: React.ReactNode }) => {
-  const [open, setOpen] = useState(false);
+  const [isOpen, setOpen] = useState(false);
   const toggle = useCallback(() => setOpen(prev => !prev), []);
-  const value = useMemo(() => ({ open, toggle }), [open, toggle]);
+  const value = useMemo(() => ({ isOpen, toggle }), [isOpen, toggle]);
 
   return (
     <div className="relative">
@@ -43,19 +44,19 @@ const Toggle = () => {
 };
 
 const BottomSheetList = ({ children }: { children?: React.ReactNode }) => {
-  const { open, toggle } = useContext(MenuContext);
+  const { isOpen, toggle } = useContext(MenuContext);
   return (
-    <BottomSheet isShow={open} onClose={toggle}>
+    <BottomSheet isShow={isOpen} onClose={toggle}>
       {children}
     </BottomSheet>
   );
 };
 
 const DropdownList = ({ children }: { children?: React.ReactNode }) => {
-  const { open } = useContext(MenuContext);
+  const { isOpen } = useContext(MenuContext);
   return (
     <>
-      {open && (
+      {isOpen && (
         <ul className="absolute right-0 top-[3rem] min-w-[10rem] rounded-[0.5rem] py-[0.5rem] shadow-[0_0_15px_rgba(0,0,0,0.05),0_1px_2px_rgba(0,0,0,0.1)]">
           {children}
         </ul>
@@ -64,9 +65,22 @@ const DropdownList = ({ children }: { children?: React.ReactNode }) => {
   );
 };
 
-const Item = ({ children }: { children?: React.ReactNode }) => {
+const Item = ({
+  onSelect,
+  children,
+}: PropsWithChildren<{ onSelect?: () => void }>) => {
+  const { toggle } = useContext(MenuContext);
+
+  const handleItemClick = () => {
+    toggle();
+    onSelect && onSelect();
+  };
+
   return (
-    <li className="block cursor-pointer list-none truncate whitespace-nowrap rounded-[0.5rem] px-[1rem] py-[0.7rem] text-sm hover:bg-black-100">
+    <li
+      className="block cursor-pointer list-none truncate whitespace-nowrap rounded-[0.5rem] px-[1rem] py-[0.7rem] text-sm hover:bg-black-100"
+      onClick={handleItemClick}
+    >
       {children}
     </li>
   );

--- a/src/v1/base/Menu.tsx
+++ b/src/v1/base/Menu.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { IconHamburger } from '@public/icons';
+import BottomSheet from './BottomSheet';
+
+type MenuContextValue = {
+  open: boolean;
+  toggle: () => void;
+};
+
+const MenuContext = createContext({} as MenuContextValue);
+
+const Menu = ({ children }: { children?: React.ReactNode }) => {
+  const [open, setOpen] = useState(false);
+  const toggle = useCallback(() => setOpen(prev => !prev), []);
+  const value = useMemo(() => ({ open, toggle }), [open, toggle]);
+
+  return (
+    <div className="relative">
+      <MenuContext.Provider value={value}>{children}</MenuContext.Provider>
+    </div>
+  );
+};
+
+const Toggle = () => {
+  const { toggle } = useContext(MenuContext);
+
+  return (
+    <div
+      className="flex h-[2.3rem] w-[2.3rem] cursor-pointer items-center justify-center"
+      onClick={toggle}
+    >
+      <IconHamburger className="h-[2rem] w-[2rem] hover:fill-black-500" />
+    </div>
+  );
+};
+
+const BottomSheetList = ({ children }: { children?: React.ReactNode }) => {
+  const { open, toggle } = useContext(MenuContext);
+  return (
+    <BottomSheet isShow={open} onClose={toggle}>
+      {children}
+    </BottomSheet>
+  );
+};
+
+const DropdownList = ({ children }: { children?: React.ReactNode }) => {
+  const { open } = useContext(MenuContext);
+  return (
+    <>
+      {open && (
+        <ul className="absolute right-0 top-[3rem] min-w-[10rem] rounded-[0.5rem] py-[0.5rem] shadow-[0_0_15px_rgba(0,0,0,0.05),0_1px_2px_rgba(0,0,0,0.1)]">
+          {children}
+        </ul>
+      )}
+    </>
+  );
+};
+
+const Item = ({ children }: { children?: React.ReactNode }) => {
+  return (
+    <li className="block cursor-pointer list-none truncate whitespace-nowrap rounded-[0.5rem] px-[1rem] py-[0.7rem] text-sm hover:bg-black-100">
+      {children}
+    </li>
+  );
+};
+
+Menu.Toggle = Toggle;
+Menu.BottomSheetList = BottomSheetList;
+Menu.DropdownList = DropdownList;
+Menu.Item = Item;
+
+export default Menu;


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- Menu 컴포넌트를 2가지 형태로 구현했어요.

1. Dropdown
    - 화면의 여유공간에 따라 드롭다운 리스트의 위치가 유동적으로 움직이도록 구현하고 싶었지만 구현하는데 오래걸릴 것 같았고, 디자인상 모든 Menu 버튼이 화면의 우측에 위치하고 있어서 드롭다운 리스트를 **버튼의 하단 우측에 고정**시켜뒀어요.
      <img width="429" alt="스크린샷 2023-12-31 오후 11 22 22" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/76c9ca3c-3b8f-4242-92ba-27def7011ad3">

2. BottomSheet
    - 앱뷰에 친화적인 BottomSheet 형태로 리스트가 보여져도 좋을 것 같아서 구현해봤어요!
      <img width="307" alt="스크린샷 2023-12-31 오후 11 23 38" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/8209f603-1427-4f34-9ebe-13361a2b1202">

<!-- - ex) 결제 기능 구현 -->

# Help
- 저는 Dropdown 리스트가 기능적으로 완벽하지 않아서 BottomSheet 리스트를 사용하면 좋을 것 같은데, 여러분들의 의견을 듣고싶어요! 자유롭게 말씀해주세요!! 🙌🏻

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #470  <!--이슈번호-->
