### PR TITLE
[#476] [모임 상세] 비로그인 시 모임 참여하기 버튼 비활성화

### DIFF
--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import Link from 'next/link';
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
 import BookGroupInfo from '@/v1/bookGroup/detail/BookGroupInfo';
 import CommentList from '@/v1/bookGroup/detail/CommentList';
 import BookGroupNavigation from '@/v1/bookGroup/BookGroupNavigation';
 import JoinBookGroupButton from '@/v1/bookGroup/detail/JoinBookGroupButton';
+import BottomActionButton from '@/v1/base/BottomActionButton';
+import { isAuthed } from '@/utils/helpers';
+import { KAKAO_LOGIN_URL } from '@/constants/url';
 
 const DetailBookGroupPage = ({
   params: { groupId },
@@ -29,7 +33,11 @@ const DetailBookGroupPage = ({
             <CommentList groupId={groupId} />
           </div>
         </div>
-        <JoinBookGroupButton groupId={groupId} />
+        {isAuthed() ? (
+          <JoinBookGroupButton groupId={groupId} />
+        ) : (
+          <LoginBottomActionButton />
+        )}
       </SSRSafeSuspense>
     </>
   );
@@ -54,3 +62,9 @@ const PageSkeleton = () => (
 );
 
 const Divider = () => <p className="w-app h-[0.5rem] bg-background"></p>;
+
+const LoginBottomActionButton = () => (
+  <Link href={KAKAO_LOGIN_URL}>
+    <BottomActionButton>로그인 및 회원가입</BottomActionButton>
+  </Link>
+);

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -2,3 +2,5 @@ export const DATA_URL = {
   placeholder:
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjWL9+/X8ABysDDapsaG4AAAAASUVORK5CYII=', // data url for placeholder color (#AFAFAF)
 };
+
+export const KAKAO_LOGIN_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;

--- a/src/v1/book/BookCover.tsx
+++ b/src/v1/book/BookCover.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef } from 'react';
 import Image from 'next/image';
 
-import { DATA_URL } from '@/constants/dataUrl';
+import { DATA_URL } from '@/constants/url';
 
 type BookCoverSize =
   | 'xsmall'


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- 로그인하지 않은 경우, `모임 참여하기` 버튼 대신 `로그인 및 회원가입` BottomActionButton이 노출되도록 수정했어요.
<!-- - ex) 결제 기능 구현 -->

# 스크린샷
<img width="382" alt="스크린샷 2024-01-18 오후 10 35 22" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/15b8c068-722f-4727-9427-e8b29ae5a6e1">

<!-- 없는 경우 생략한다. -->

# 관련 이슈

- Close #476 <!--이슈번호-->
