### PR TITLE
[#491] [도서 검색] 베스트셀러 클릭 시 라우팅 경로 수정 (알라딘 -> 다독다독)

### DIFF
--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -89,12 +89,14 @@ export type BookComment = {
   content: APIBookComment['contents'];
 };
 export interface APIBestSeller {
-  isbn: string;
   title: string;
   author: string;
-  cover: string;
-  bestRank: number;
+  isbn: string;
+  description: string;
   link: string;
+  cover: string;
+  publisher: string;
+  bestRank: number;
 }
 
 export interface APIBestSellerRes {

--- a/src/v1/bookSearch/BestSellers.tsx
+++ b/src/v1/bookSearch/BestSellers.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
-import type { APIBestSellerSearchRange } from '@/types/book';
+import type { APIBestSellerSearchRange, APISearchedBook } from '@/types/book';
 import useBestSellersQuery from '@/queries/book/useBestSellersQuery';
+import bookAPI from '@/apis/book';
 
 import BookCover from '@/v1/book/BookCover';
+import useToast from '@/v1/base/Toast/useToast';
 
 const SEARCH_RANGES = {
   주간: 'WEEKLY',
@@ -17,14 +19,31 @@ type SearchRangeTypes = keyof typeof SEARCH_RANGES;
 const BestSellers = () => {
   const [bestSellerSearchRange, setBestSellerSearchRange] =
     useState<APIBestSellerSearchRange>('WEEKLY');
-
-  const bestSellersInfo = useBestSellersQuery();
-
   const searchRanges = Object.keys(SEARCH_RANGES) as SearchRangeTypes[];
 
+  const bestSellersInfo = useBestSellersQuery();
   const bestSellers = bestSellersInfo.isSuccess
     ? bestSellersInfo.data.item
     : [];
+
+  const router = useRouter();
+  const toast = useToast();
+
+  const handleClickBook = async (book: APISearchedBook) => {
+    try {
+      const {
+        data: { bookId },
+      } = await bookAPI.createBook({ book });
+
+      router.push(`/book/${bookId}`);
+    } catch (error) {
+      toast.show({
+        type: 'error',
+        message: '잠시 후 다시 시도해주세요',
+      });
+      console.error(error);
+    }
+  };
 
   return (
     <section className="flex flex-col gap-[1.7rem]">
@@ -58,9 +77,13 @@ const BestSellers = () => {
               key={book.isbn}
               title={book.title}
               author={book.author}
+              isbn={book.isbn}
+              contents={book.description}
+              url={book.link}
               imageUrl={book.cover}
+              publisher={book.publisher}
               bestRank={book.bestRank}
-              link={book.link}
+              handleClickBook={handleClickBook}
             />
           ))}
         </ul>
@@ -78,23 +101,41 @@ export default BestSellers;
 type BestSellerProps = {
   title: string;
   author: string;
+  isbn: string;
+  contents: string;
+  url: string;
   imageUrl: string;
+  publisher: string;
   bestRank: number;
-  link: string;
+  handleClickBook: (book: APISearchedBook) => Promise<void>;
 };
 
 const BestSeller = ({
   title,
   author,
+  isbn,
+  contents,
+  url,
   imageUrl,
+  publisher,
   bestRank,
-  link,
+  handleClickBook,
 }: BestSellerProps) => {
+  const createBookReqBody = {
+    title: title,
+    author: author,
+    isbn: isbn,
+    contents: contents,
+    url: url,
+    imageUrl: imageUrl,
+    publisher: publisher,
+    apiProvider: 'ALADIN',
+  };
+
   return (
-    <Link
-      href={link}
-      target="_blank"
-      className="flex w-[12.7rem] flex-col gap-[1.3rem] px-[0.7rem]"
+    <div
+      className="flex w-[12.7rem] cursor-pointer flex-col gap-[1.3rem] px-[0.7rem]"
+      onClick={() => handleClickBook(createBookReqBody)}
     >
       <BookCover src={imageUrl} title={title} size={'xlarge'} />
       <div className="flex flex-row gap-[1rem]">
@@ -108,6 +149,6 @@ const BestSeller = ({
           <p className="line-clamp-1 text-sm text-[#5c5c5c]">{author}</p>
         </div>
       </div>
-    </Link>
+    </div>
   );
 };

--- a/src/v1/bookSearch/BestSellers.tsx
+++ b/src/v1/bookSearch/BestSellers.tsx
@@ -121,21 +121,21 @@ const BestSeller = ({
   bestRank,
   onClick,
 }: BestSellerProps) => {
-  const createBookReqBody = {
-    title: title,
-    author: author,
-    isbn: isbn,
-    contents: contents,
-    url: url,
-    imageUrl: imageUrl,
-    publisher: publisher,
+  const bookReqBody = {
+    title,
+    author,
+    isbn,
+    contents,
+    url,
+    imageUrl,
+    publisher,
     apiProvider: 'ALADIN',
   };
 
   return (
     <div
       className="flex w-[12.7rem] cursor-pointer flex-col gap-[1.3rem] px-[0.7rem]"
-      onClick={() => onClick(createBookReqBody)}
+      onClick={() => onClick(bookReqBody)}
     >
       <BookCover src={imageUrl} title={title} size={'xlarge'} />
       <div className="flex flex-row gap-[1rem]">

--- a/src/v1/bookSearch/BestSellers.tsx
+++ b/src/v1/bookSearch/BestSellers.tsx
@@ -83,7 +83,7 @@ const BestSellers = () => {
               imageUrl={book.cover}
               publisher={book.publisher}
               bestRank={book.bestRank}
-              handleClickBook={handleClickBook}
+              onClick={handleClickBook}
             />
           ))}
         </ul>
@@ -107,7 +107,7 @@ type BestSellerProps = {
   imageUrl: string;
   publisher: string;
   bestRank: number;
-  handleClickBook: (book: APISearchedBook) => Promise<void>;
+  onClick: (book: APISearchedBook) => Promise<void>;
 };
 
 const BestSeller = ({
@@ -119,7 +119,7 @@ const BestSeller = ({
   imageUrl,
   publisher,
   bestRank,
-  handleClickBook,
+  onClick,
 }: BestSellerProps) => {
   const createBookReqBody = {
     title: title,
@@ -135,7 +135,7 @@ const BestSeller = ({
   return (
     <div
       className="flex w-[12.7rem] cursor-pointer flex-col gap-[1.3rem] px-[0.7rem]"
-      onClick={() => handleClickBook(createBookReqBody)}
+      onClick={() => onClick(createBookReqBody)}
     >
       <BookCover src={imageUrl} title={title} size={'xlarge'} />
       <div className="flex flex-row gap-[1rem]">


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
### 베스트셀러 클릭 시 라우팅 경로 수정 (알라딘 -> 다독다독)
베스트셀러를 클릭하면 해당 도서 정보를 DB에 저장하고 다독다독 책 상세 페이지로 이동합니다.

# 스크린샷

https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/f9e1cfe6-acee-42fc-b981-5b57adab2e1e


# pr 포인트

<!-- - ex) XX를 중점적으로 봐주세요. -->

# Help

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #491 
