### PR TITLE
[#507] [프로필] 로그아웃 햄버거 구현

### DIFF
--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -1,19 +1,25 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { checkAuthentication, removeAuth } from '@/utils/helpers';
+
 import userAPI from '@/apis/user';
+
+import { checkAuthentication, removeAuth } from '@/utils/helpers';
+
+import { IconArrowRight } from '@public/icons';
+
+import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+
+import Avatar from '@/v1/base/Avatar';
+import Button from '@/v1/base/Button';
+import Loading from '@/v1/base/Loading';
+import Menu from '@/v1/base/Menu';
 import TopHeader from '@/v1/base/TopHeader';
-import ProfileInfo from '@/v1/profile/info/ProfileInfo';
+import BookShelf from '@/v1/bookShelf/BookShelf';
 import ProfileBookShelf from '@/v1/profile/bookShelf/ProfileBookShelf';
 import ProfileGroup from '@/v1/profile/group/ProfileGroup';
-import Avatar from '@/v1/base/Avatar';
-import Link from 'next/link';
-import { IconArrowRight } from '@public/icons';
-import BookShelf from '@/v1/bookShelf/BookShelf';
-import SSRSafeSuspense from '@/components/SSRSafeSuspense';
-import Loading from '@/v1/base/Loading';
-import Button from '@/v1/base/Button';
+import ProfileInfo from '@/v1/profile/info/ProfileInfo';
 
 const USER_ID = 'me';
 const KAKAO_LOGIN_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
@@ -80,7 +86,12 @@ const MyProfileForAuth = () => {
   return (
     <>
       <TopHeader text="Profile">
-        <button onClick={handleLogoutButtonClick}>로그아웃</button>
+        <Menu>
+          <Menu.Toggle />
+          <Menu.DropdownList>
+            <Menu.Item onSelect={handleLogoutButtonClick}>로그아웃</Menu.Item>
+          </Menu.DropdownList>
+        </Menu>
       </TopHeader>
       <div className="flex flex-col gap-[2rem]">
         <ProfileInfo userId={USER_ID} />

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -20,6 +20,8 @@ import BookShelf from '@/v1/bookShelf/BookShelf';
 import ProfileBookShelf from '@/v1/profile/bookShelf/ProfileBookShelf';
 import ProfileGroup from '@/v1/profile/group/ProfileGroup';
 import ProfileInfo from '@/v1/profile/info/ProfileInfo';
+import userKeys from '@/queries/user/key';
+import { useQueryClient } from '@tanstack/react-query';
 
 const USER_ID = 'me';
 const KAKAO_LOGIN_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
@@ -75,11 +77,13 @@ const MyProfileForUnAuth = () => {
 };
 
 const MyProfileForAuth = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
 
   const handleLogoutButtonClick = async () => {
     await userAPI.logout();
     removeAuth();
+    queryClient.removeQueries({ queryKey: userKeys.me(), exact: true });
     router.refresh();
   };
 


### PR DESCRIPTION
# 구현 내용

로그인시 프로필 페이지에 햄버거 메뉴를 추가했어요.

# 스크린샷

https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/bc476574-575f-4ee8-b3ba-59976014d4c6

# pr 포인트

로컬에서 로그인했을 때 쿠키에 RefreshToken이 담기지 않아
배포환경에서 직접 로그인하여 받은 RefreshToken을 로컬환경으로 복사하여 테스트를 진행했습니다

# 추가사항 (#499)

https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/2a88221f-0334-4d20-866d-0bb79f8d8341

이제 더 이상 로그아웃 이후, query 데이터가 fresh 상태로 남지 않습니다.
stale상태로 넘기기 보다 개인정보인 만큼 removeQuery 메서드로 제거하는게 맞다고 판단했어요.

# 관련 이슈

- Close #507 
- Close #499 