### PR TITLE
[#535] [독서모임] 독서모임 목록 페이지 개선

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -31,7 +31,7 @@ const GroupPage = () => {
   const isAuthenticated = checkAuthentication();
 
   const handleSearchInputClick = () => {
-    alert('아직 준비 중인 기능이에요.');
+    showToast({ message: '아직 준비 중인 기능이에요 🥹', type: 'normal' });
   };
 
   const handleCreateGroupClick = () => {

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -72,7 +72,7 @@ const MyBookGroupList = () => {
   const { data: myId } = useMyProfileId({ enabled: isAuthenticated });
 
   return (
-    <div className="flex gap-[1rem] overflow-scroll">
+    <section className="flex gap-[1rem] overflow-scroll">
       {bookGroups.map(({ title, book, bookGroupId, owner }) => (
         <SimpleBookGroupCard
           key={bookGroupId}
@@ -82,7 +82,7 @@ const MyBookGroupList = () => {
           bookGroupId={bookGroupId}
         />
       ))}
-    </div>
+    </section>
   );
 };
 
@@ -145,7 +145,7 @@ const EntireBookGroupList = () => {
 
   return (
     <>
-      <div className="flex flex-col gap-[1rem]">
+      <section className="flex flex-col gap-[1rem]">
         {isSuccess &&
           data.pages.map(({ bookGroups }) =>
             bookGroups.map(
@@ -179,7 +179,7 @@ const EntireBookGroupList = () => {
               )
             )
           )}
-      </div>
+      </section>
       {isFetchingNextPage && <DetailBookGroupCardSkeleton />}
       <div ref={ref} />
     </>

--- a/src/app/profile/me/group/page.tsx
+++ b/src/app/profile/me/group/page.tsx
@@ -31,7 +31,7 @@ const UserGroupContent = () => {
         {Array.from({ length: 4 }).map((_, index) => (
           <li
             key={index}
-            className="border-placeholder px-[1.6rem] py-[0.9rem] shadow-[0_0_0.6rem_rgba(180,180,180,0.25)]"
+            className="border-placeholder px-[1.6rem] py-[0.9rem] shadow-bookgroup-card"
           >
             <div className="flex gap-[0.5rem] [&>*]:rounded-[0.5rem]">
               <div className="h-[1.9rem] w-[4.34rem] bg-placeholder" />

--- a/src/v1/base/TopHeader.tsx
+++ b/src/v1/base/TopHeader.tsx
@@ -6,10 +6,10 @@ type TopHeaderProps = PropsWithChildren<{
 
 const TopHeader = ({ text, children }: TopHeaderProps) => {
   return (
-    <div className="flex w-full items-center justify-between pb-[2.8rem]">
+    <header className="flex w-full items-center justify-between pb-[2.8rem]">
       <h1 className="text-xl font-bold text-main-900">{text}</h1>
       {children}
-    </div>
+    </header>
   );
 };
 

--- a/src/v1/bookGroup/DetailBookGroupCard.tsx
+++ b/src/v1/bookGroup/DetailBookGroupCard.tsx
@@ -30,7 +30,7 @@ const DetailBookGroupCard = ({
 }: DetailBookGroupCardProps) => {
   return (
     <Link href={`/group/${bookGroupId}`}>
-      <div className="w-full rounded-[0.4rem] p-[1.5rem] shadow-[0_0_0.6rem_rgba(180,180,180,0.25)]">
+      <div className="w-full rounded-[0.4rem] p-[1.5rem] shadow-bookgroup-card">
         <div className="flex gap-[0.5rem]">
           <BookGroupStatus start={date.start} end={date.end} />
           <Public isPublic={isPublic} />
@@ -140,7 +140,7 @@ const CommentCount = ({ commentCount }: { commentCount: number }) => {
 };
 
 export const DetailBookGroupCardSkeleton = () => (
-  <div className="w-full animate-pulse rounded-[0.5rem] p-[1.5rem] shadow-[0_0_0.6rem_rgba(180,180,180,0.25)]">
+  <div className="w-full animate-pulse rounded-[0.5rem] p-[1.5rem] shadow-bookgroup-card">
     <div className="flex gap-[0.5rem]">
       <div className="h-[1.9rem] w-[4.8rem] rounded-[0.5rem] bg-black-400" />
       <div className="h-[2rem] w-[3.8rem] rounded-[0.5rem] bg-black-400" />

--- a/src/v1/bookGroup/DetailBookGroupCard.tsx
+++ b/src/v1/bookGroup/DetailBookGroupCard.tsx
@@ -36,7 +36,7 @@ const DetailBookGroupCard = ({
           <Public isPublic={isPublic} />
         </div>
         <div className="flex justify-between gap-[1.5rem] pt-[1rem]">
-          <div className="flex flex-grow flex-col justify-between ">
+          <div className="flex min-w-0 flex-grow flex-col justify-between ">
             <Title title={title} />
             <Description description={description} />
             <Duration start={date.start} end={date.end} />
@@ -67,11 +67,11 @@ const Public = ({ isPublic }: { isPublic: boolean }) => (
 );
 
 const Title = ({ title }: { title: string }) => {
-  return <div className="w-[22rem] truncate text-md font-bold">{title}</div>;
+  return <p className="min-w-0 truncate text-md font-bold">{title}</p>;
 };
 
 const Description = ({ description }: { description: string }) => {
-  return <div className="w-[22rem] truncate text-sm">{description}</div>;
+  return <p className="min-w-0 truncate text-sm">{description}</p>;
 };
 
 const Duration = ({ start, end }: { start: string; end: string }) => {

--- a/src/v1/bookGroup/DetailBookGroupCard.tsx
+++ b/src/v1/bookGroup/DetailBookGroupCard.tsx
@@ -30,7 +30,7 @@ const DetailBookGroupCard = ({
 }: DetailBookGroupCardProps) => {
   return (
     <Link href={`/group/${bookGroupId}`}>
-      <div className="w-full rounded-[0.4rem] p-[1.5rem] shadow-bookgroup-card">
+      <article className="w-full rounded-[0.4rem] p-[1.5rem] shadow-bookgroup-card">
         <div className="flex gap-[0.5rem]">
           <BookGroupStatus start={date.start} end={date.end} />
           <Public isPublic={isPublic} />
@@ -53,7 +53,7 @@ const DetailBookGroupCard = ({
           </div>
           <BookCover src={bookImageSrc} size="medium" />
         </div>
-      </div>
+      </article>
     </Link>
   );
 };
@@ -84,14 +84,10 @@ const Duration = ({ start, end }: { start: string; end: string }) => {
 
   return (
     <div className="flex items-center gap-[0.5rem]">
-      <div>
-        <IconCalendar className="h-[1.161rem] w-[1.1rem] fill-placeholder" />
-      </div>
-      <div className="text-xs text-placeholder">
-        <span className="pt-[0.1rem]">
-          {formatDateTime(start)} - {formatDateTime(end)}
-        </span>
-      </div>
+      <IconCalendar className="w-[1.2rem] fill-placeholder" />
+      <p className="text-xs text-placeholder">
+        {formatDateTime(start)} - {formatDateTime(end)}
+      </p>
     </div>
   );
 };
@@ -107,7 +103,7 @@ const Owner = ({
     <div className="flex h-[2rem] gap-[0.5rem]">
       <Avatar name={name} src={profileImageSrc} size="small" />
       <div className="flex items-center text-xs">
-        <span>{name}</span>
+        <p>{name}</p>
       </div>
     </div>
   );
@@ -116,12 +112,8 @@ const Owner = ({
 const MemberCount = ({ memberCount }: { memberCount: number }) => {
   return (
     <div className="flex items-center gap-[0.3rem]">
-      <span className="h-auto w-[1.3rem] fill-placeholder">
-        <IconMembers className="h-[0.9rem] w-[1.3rem] fill-placeholder" />
-      </span>
-      <span className="text-xs text-placeholder">
-        <span className="text-placeholder">{memberCount}</span>
-      </span>
+      <IconMembers className="h-[0.9rem] w-[1.3rem] fill-placeholder" />
+      <p className="text-xs text-placeholder">{memberCount}</p>
     </div>
   );
 };
@@ -129,12 +121,8 @@ const MemberCount = ({ memberCount }: { memberCount: number }) => {
 const CommentCount = ({ commentCount }: { commentCount: number }) => {
   return (
     <div className="flex items-center gap-[0.3rem]">
-      <div className="h-auto w-[1.3rem] fill-placeholder">
-        <IconComments className="h-[1.2rem] w-[1.2rem] fill-placeholder" />
-      </div>
-      <span className="text-xs text-placeholder">
-        <span className="text-placeholder">{commentCount}</span>
-      </span>
+      <IconComments className="h-[1.2rem] w-[1.2rem] fill-placeholder" />
+      <p className="text-xs text-placeholder">{commentCount}</p>
     </div>
   );
 };

--- a/src/v1/bookGroup/SearchGroup.tsx
+++ b/src/v1/bookGroup/SearchGroup.tsx
@@ -6,7 +6,7 @@ interface SearchGroup {
 
 const SearchGroup = ({ onClick }: SearchGroup) => {
   return (
-    <div className="flex">
+    <section className="flex">
       <div className="rounded-bl-[0.4rem] rounded-tl-[0.4rem] border-[0.1rem] border-r-[0rem] border-solid border-black-100 bg-[#fffff] pl-[1rem] pt-[0.8rem]">
         <IconSearch className="fill-placeholder" />
       </div>
@@ -17,7 +17,7 @@ const SearchGroup = ({ onClick }: SearchGroup) => {
         type="text"
         onClick={onClick}
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/v1/bookGroup/SearchGroup.tsx
+++ b/src/v1/bookGroup/SearchGroup.tsx
@@ -1,24 +1,25 @@
 import { IconSearch } from '@public/icons';
 
-interface SearchGroup {
-  onClick: () => void;
+interface SearchGroupInputProps {
+  onClick?: () => void;
 }
 
-const SearchGroup = ({ onClick }: SearchGroup) => {
+const SearchGroupInput = ({ onClick }: SearchGroupInputProps) => {
   return (
     <section className="flex">
-      <div className="rounded-bl-[0.4rem] rounded-tl-[0.4rem] border-[0.1rem] border-r-[0rem] border-solid border-black-100 bg-[#fffff] pl-[1rem] pt-[0.8rem]">
+      <div className="rounded-bl-[0.4rem] rounded-tl-[0.4rem] border-[0.1rem] border-r-[0rem] border-solid border-black-100 bg-white pl-[1rem] pt-[0.8rem]">
         <IconSearch className="fill-placeholder" />
       </div>
       <input
         id="groupSearching"
-        className="h-[3.7rem] w-full rounded-br-[0.4rem] rounded-tr-[0.4rem] border-[0.1rem] border-l-[0rem] border-black-100 pl-[2rem] text-[1.4rem] leading-[1.6rem] placeholder:text-placeholder focus:outline-0"
+        className="h-[3.7rem] w-full rounded-br-[0.4rem] rounded-tr-[0.4rem] border-[0.1rem] border-l-[0rem] border-black-100 pl-[2rem] text-[1.4rem] leading-[1.6rem] placeholder:text-placeholder focus:outline-0 disabled:cursor-not-allowed disabled:bg-white"
         placeholder="모임을 검색해보세요"
         type="text"
         onClick={onClick}
+        readOnly
       />
     </section>
   );
 };
 
-export default SearchGroup;
+export default SearchGroupInput;

--- a/src/v1/bookGroup/SimpleBookGroupCard.tsx
+++ b/src/v1/bookGroup/SimpleBookGroupCard.tsx
@@ -16,14 +16,14 @@ const SimpleBookGroupCard = ({
 }: SimpleBookGroupCardProps) => {
   return (
     <Link href={`/group/${bookGroupId}`}>
-      <div className="flex w-[10rem] flex-col gap-[1rem]">
+      <article className="flex w-[10rem] flex-col gap-[1rem]">
         <div className="bg-orange-100 px-[1.8rem] py-[1.6rem]">
           <BookCover size="xsmall" src={imageSource} />
         </div>
         <p className="break-keep text-center text-xs leading-tight">
           {isOwner ? `👑 ${title}` : title}
         </p>
-      </div>
+      </article>
     </Link>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -81,6 +81,7 @@ module.exports = {
         bottomNav: 'rgba(0, 0, 0, 0.05) 0px 0px 10px 1px',
         'floating-button':
           '0px 0px 2px rgba(0, 0, 0, 0.2), 2px 2px 6px rgba(0, 0, 0, 0.1)',
+        'bookgroup-card': '0 0 6px rgba(180,180,180,0.25)',
       },
       keyframes: {
         'page-transition': {


### PR DESCRIPTION
# 구현 내용

- 화면 크기가 줄어들었을 때, 모임상세 카드 요소들이 컨테이너 밖으로 나오는 현상 수정
- 시맨틱 태그 적용
- 불필요한 div 요소 제거

# 스크린샷
### BEFORE
![image](https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/2ce78a59-b9a9-4434-ad4e-b85c8a047120)

### AFTER
https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/7fa78bac-bf49-4bdf-942e-ba8d35f296d0

# pr 포인트

코멘트로 남겨두었습니다

# 관련 이슈

- Close #535 
