### PR TITLE
[#549] 'unable to verify first certificate' 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -H local.dev.dadok.app",
-    "ssl-dev": "node scripts/server.js local.dev.dadok.app",
+    "dev-ssl": "node scripts/server.js local.dev.dadok.app",
     "build": "next build",
     "start": "next start -H local.dev.dadok.app",
     "lint": "next lint",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const https = require('https');
 const { parse } = require('url');
+const { execSync } = require('child_process');
 const next = require('next');
 
 const dev = process.env.NODE_ENV !== 'production';
@@ -13,6 +14,7 @@ const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 
 const SELF_CERTIFICATES_PATH = {
+  ca: `${execSync('mkcert -CAROOT').toString().replace(/\s/g, '')}/rootCA.pem`,
   key: './.certificates/localhost-key.pem',
   cert: './.certificates/localhost.pem',
 };
@@ -21,6 +23,9 @@ const option = {
   key: fs.readFileSync(SELF_CERTIFICATES_PATH.key),
   cert: fs.readFileSync(SELF_CERTIFICATES_PATH.cert),
 };
+
+// To resolve the 'unable to verify first certificate' error
+process.env.NODE_EXTRA_CA_CERTS = SELF_CERTIFICATES_PATH.ca;
 
 app.prepare().then(() => {
   https
@@ -38,6 +43,6 @@ app.prepare().then(() => {
     })
     .listen(port, error => {
       if (error) throw error;
-      console.log(`> Ready on https://${hostname}:${port}`);
+      console.log('\x1b[32m%s', `> ready on https://${hostname}:${port}\n`);
     });
 });


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- node 환경에서 axios로 https 요청 시 발생하는 'unable to verify first certificate' 에러를 해결했어요.
- next custom 서버 구동 시 `NODE_EXTRA_CA_CERTS` 환경변수에 mkcert rootCA 인증서를 설정하도록 수정했어요.

<!-- - ex) 결제 기능 구현 -->

<!-- 팀원들의 의견이 필요하거나 도움이 필요한 경우 작성한다. -->
<!-- 팀원들이 이해할수 있도록 상세히 작성한다. -->
<!-- - ex) 이부분 도저히 어떻게야 할지 모르겠어요 -->
<!-- - ex) 여기 도저히 테스트 통과하지 않고 이상해요 -->

# 관련 이슈

- Close #549 <!--이슈번호-->
