### PR TITLE
[#554] 스토리북 preview decorator에서 Layout 제거

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -72,16 +72,13 @@ const preview: Preview = {
     nextjs: {
       appDirectory: true,
     },
-    layout: 'fullscreen',
   },
   loaders: [mswLoader],
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <Layout>
-            <Story />
-          </Layout>
+          <Story />
         </ToastProvider>
       </QueryClientProvider>
     ),

--- a/src/stories/meta.tsx
+++ b/src/stories/meta.tsx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/react';
+import Layout from '@/v1/layout/Layout';
+
+export const appLayoutMeta: Meta = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="m-auto max-w-[43rem] bg-white">
+        <Layout>
+          <Story />
+        </Layout>
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- 스토리북 preview에서 Layout를 제거하고, 전체 앱 레이아웃이 필요한 스토리에서는 `appLayoutMeta`를 추가해서 사용할 수 있도록 수정했어요.

```tsx
const meta: Meta<typeof SelectBookStep> = {
  title: 'bookGroup/funnel/SelectBookStep',
  component: SelectBookStep,
  ...appLayoutMeta,
};
```


<!-- - ex) 결제 기능 구현 -->

# 관련 이슈

- Close #554 <!--이슈번호-->
