### PR TITLE
[#553] [모임 생성] 모임 상세 퍼널

### DIFF
--- a/src/constants/groupRadioValues.ts
+++ b/src/constants/groupRadioValues.ts
@@ -40,3 +40,12 @@ export const HAS_JOIN_PASSWORD_VALUE = [
 ];
 
 export const HAS_JOIN_PASSWORD_DEFAULT_VALUE = 'false';
+
+export const MAX_MEMBER_COUNT_OPTIONS = [
+  { label: '제한없음', value: 9999 },
+  { label: '50명', value: 50 },
+  { label: '100명', value: 100 },
+  { label: '200명', value: 200 },
+  { label: '500명', value: 500 },
+  { label: '직접 입력', value: 'custom' },
+] as const;

--- a/src/stories/bookGroup/create/funnel/SetUpDetailStep.stories.tsx
+++ b/src/stories/bookGroup/create/funnel/SetUpDetailStep.stories.tsx
@@ -1,3 +1,7 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import type { APICreateGroup } from '@/types/group';
+import { getTodayDate } from '@/utils/date';
+
 import { SetUpDetailStep } from '@/v1/bookGroup/create/funnel';
 import { Meta, StoryObj } from '@storybook/react';
 
@@ -10,7 +14,36 @@ const meta: Meta<typeof SetUpDetailStep> = {
 export default meta;
 
 type Story = StoryObj<typeof SetUpDetailStep>;
+interface FunnelFormValues extends APICreateGroup {
+  customMemberCount: string | number;
+}
+
+const SetUpDetailForm = () => {
+  const methods = useForm<FunnelFormValues>({
+    mode: 'all',
+    defaultValues: {
+      bookId: 23,
+      title: '',
+      introduce: '',
+      maxMemberCount: 9999,
+      startDate: getTodayDate(),
+      endDate: '',
+      isPublic: false,
+      hasJoinPasswd: false,
+      joinQuestion: '',
+      joinPasswd: '',
+    },
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <SetUpDetailStep />
+      </form>
+    </FormProvider>
+  );
+};
 
 export const Default: Story = {
-  args: {},
+  render: () => <SetUpDetailForm />,
 };

--- a/src/v1/base/RadioButton.tsx
+++ b/src/v1/base/RadioButton.tsx
@@ -1,14 +1,14 @@
 import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
 
+type RadioButtonProps = {
+  label?: string;
+} & Omit<ComponentPropsWithoutRef<'input'>, 'id' | 'type' | 'className'>;
+
 const BASE_RADIO_BUTTON_CLASSES =
   'px-[1.2rem] py-[0.5rem] bg-main-600/[0.18] text-main-900 text-sm font-normal rounded-[2rem] cursor-pointer w-full h-full peer-checked:bg-main-900 peer-checked:text-white';
 
 const RadioButton = (
-  {
-    name,
-    value,
-    ...props
-  }: Omit<ComponentPropsWithoutRef<'input'>, 'id' | 'type' | 'className'>,
+  { name, value, label, ...props }: RadioButtonProps,
   ref: Ref<HTMLInputElement>
 ) => {
   return (
@@ -22,7 +22,7 @@ const RadioButton = (
         ref={ref}
         {...props}
       />
-      <span className={BASE_RADIO_BUTTON_CLASSES}>{value}</span>
+      <span className={BASE_RADIO_BUTTON_CLASSES}>{label ?? value}</span>
     </label>
   );
 };

--- a/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
@@ -56,7 +56,7 @@ const SetUpDetailStep = ({
       <SelectedBookInfoField bookId={getValues('bookId')} />
       <IntroduceField errors={errors} register={register} />
       <MaxMemberCountField
-        isMaxMemberCountCustom={watch('maxMemberCount') === 'custom'}
+        isCustomMemberCount={watch('maxMemberCount') === 'custom'}
         errors={errors}
         register={register}
       />
@@ -144,11 +144,11 @@ const IntroduceField = ({ errors, register }: _DefaultFieldProps) => {
 };
 
 const MaxMemberCountField = ({
-  isMaxMemberCountCustom,
+  isCustomMemberCount,
   errors,
   register,
 }: {
-  isMaxMemberCountCustom: boolean;
+  isCustomMemberCount: boolean;
 } & _DefaultFieldProps) => {
   return (
     <section className="flex flex-col gap-[1.6rem]">
@@ -168,14 +168,14 @@ const MaxMemberCountField = ({
         </div>
         <ErrorMessage>{errors?.maxMemberCount?.message}</ErrorMessage>
       </div>
-      {isMaxMemberCountCustom && (
+      {isCustomMemberCount && (
         <div className="flex flex-col gap-[0.5rem]">
           <Input
             type="number"
             placeholder="1000명 이상의 인원은 제한 없음을 선택해주세요"
             {...register?.('customMemberCount', {
               required: {
-                value: isMaxMemberCountCustom,
+                value: isCustomMemberCount,
                 message: '모임 최대 인원을 입력해주세요',
               },
               min: { value: 2, message: '모임 인원은 최소 2명부터 가능해요' },

--- a/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
@@ -1,3 +1,14 @@
+import {
+  type FieldErrors,
+  type UseFormRegister,
+  useFormContext,
+} from 'react-hook-form';
+
+import type { APICreateGroup } from '@/types/group';
+
+import { getTodayDate } from '@/utils/date';
+
+import BottomActionButton from '@/v1/base/BottomActionButton';
 import DatePicker from '@/v1/base/DatePicker';
 import ErrorMessage from '@/v1/base/ErrorMessage';
 import Input from '@/v1/base/Input';
@@ -7,65 +18,238 @@ import Switch from '@/v1/base/Switch';
 import TextArea from '@/v1/base/TextArea';
 import BookInfoCard from '../../BookInfoCard';
 
-const SetUpDetailStep = () => {
+interface MoveFunnelStepProps {
+  onPrevStep?: () => void;
+  onNextStep?: () => void;
+  onSubmit?: () => void;
+}
+
+interface SetUpDetailStepValues
+  extends Pick<
+    APICreateGroup,
+    'bookId' | 'title' | 'introduce' | 'startDate' | 'endDate' | 'isPublic'
+  > {
+  maxMemberCount: string | number;
+  customMemberCount: string | number;
+}
+
+const MAX_MEMBER_COUNT_OPTIONS = [
+  { label: '제한없음', value: 9999 },
+  { label: '50명', value: 50 },
+  { label: '100명', value: 100 },
+  { label: '200명', value: 200 },
+  { label: '500명', value: 500 },
+  { label: '직접 입력', value: 'custom' },
+] as const;
+
+const SetUpDetailStep = ({
+  // FIXME: goToEnterTitleStep,
+  onNextStep,
+}: MoveFunnelStepProps) => {
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    watch,
+    formState: { errors },
+  } = useFormContext<SetUpDetailStepValues>();
+
   return (
-    <div className="flex flex-col gap-[3.2rem]">
-      <section className="flex flex-col gap-[0.5rem]">
-        <Input fontSize="large" inputStyle="line" error={true} />
-        <div className="flex flex-row-reverse justify-between gap-[0.4rem]">
-          <InputLength maxLength={20} isError={true} />
-          {true && <ErrorMessage>{'마크업용 에러 표시'}</ErrorMessage>}
-        </div>
-      </section>
+    <article className="flex flex-col gap-[3.2rem] overflow-y-scroll pb-[7rem]">
+      <TitleField
+        currentLength={watch('title')?.length}
+        errors={errors}
+        register={register}
+      />
+      <SelectedBookInfoField bookId={getValues('bookId')} />
+      <IntroduceField errors={errors} register={register} />
+      <MaxMemberCountField
+        isMaxMemberCountCustom={watch('maxMemberCount') === 'custom'}
+        errors={errors}
+        register={register}
+      />
+      <PickDateField
+        selectedStartDate={watch('startDate')}
+        errors={errors}
+        register={register}
+      />
+      <SwitchIsPublicField register={register} />
 
-      <section>
-        <BookInfoCard removable={true} />
-      </section>
-
-      <section className="flex flex-col gap-[1.6rem]">
-        <h2>활동 내용</h2>
-        <>
-          <TextArea
-            count={true}
-            placeholder="독서모임에서 어떤 활동을 할 계획인지 자세히 설명해주세요."
-          />
-        </>
-      </section>
-
-      <section className="flex flex-col gap-[1.6rem]">
-        <h2>최대 인원</h2>
-        <div className="inline-flex w-[23rem] flex-wrap gap-[1rem]">
-          <RadioButton value="제한없음" />
-          <RadioButton value="50명" />
-          <RadioButton value="100명" />
-          <RadioButton value="200명" />
-          <RadioButton value="500명" />
-          <RadioButton value="직접 입력" />
-        </div>
-        {false && <Input />}
-      </section>
-
-      <section className="flex items-center justify-between">
-        <h2>모임 시작일</h2>
-        <DatePicker />
-      </section>
-
-      <section className="flex items-center justify-between">
-        <h2>모임 종료일</h2>
-        <DatePicker />
-      </section>
-
-      <section className="flex items-start justify-between">
-        <div className="flex min-w-0 flex-col gap-[0.3rem]">
-          <h2>댓글 공개 여부</h2>
-          <p className="text-xs text-placeholder">
-            모임에 가입하지 않은 사람도 댓글을 볼 수 있어요.
-          </p>
-        </div>
-        <Switch />
-      </section>
-    </div>
+      <BottomActionButton
+        type="submit"
+        onClick={handleSubmit(() => onNextStep?.())}
+      >
+        다음
+      </BottomActionButton>
+    </article>
   );
 };
 
 export default SetUpDetailStep;
+
+interface _DefaultFieldProps {
+  errors?: FieldErrors<SetUpDetailStepValues>;
+  register?: UseFormRegister<SetUpDetailStepValues>;
+}
+
+const TitleField = ({
+  currentLength,
+  errors,
+  register,
+}: {
+  currentLength: number;
+} & _DefaultFieldProps) => {
+  return (
+    <section className="flex flex-col gap-[0.5rem]">
+      <Input
+        fontSize="large"
+        inputStyle="line"
+        error={!!errors?.title}
+        {...register?.('title', {
+          required: '독서모임 이름을 적어주세요',
+          minLength: { value: 2, message: '2글자 이상 입력해주세요' },
+          maxLength: { value: 20, message: '20글자 이하로 입력해주세요' },
+        })}
+      />
+      <div className="flex flex-row-reverse justify-between gap-[0.4rem]">
+        <InputLength
+          currentLength={currentLength}
+          maxLength={20}
+          isError={!!errors?.title}
+        />
+        <ErrorMessage>{errors?.title?.message}</ErrorMessage>
+      </div>
+    </section>
+  );
+};
+
+const SelectedBookInfoField = ({ bookId }: { bookId?: number }) => {
+  return (
+    <section>
+      <BookInfoCard bookId={bookId} removable={true} />
+    </section>
+  );
+};
+
+const IntroduceField = ({ errors, register }: _DefaultFieldProps) => {
+  return (
+    <section className="flex flex-col gap-[1.6rem]">
+      <h2>활동 내용</h2>
+      <TextArea
+        count={true}
+        error={!!errors?.introduce}
+        placeholder="독서모임에서 어떤 활동을 할 계획인지 자세히 설명해주세요"
+        {...register?.('introduce', {
+          required: '독서모임에 대한 설명을 적어주세요',
+          minLength: { value: 10, message: '10글자 이상 입력해주세요' },
+          maxLength: { value: 500, message: '500자 이하로 입력해주세요' },
+        })}
+      >
+        <ErrorMessage>{errors?.introduce?.message}</ErrorMessage>
+      </TextArea>
+    </section>
+  );
+};
+
+const MaxMemberCountField = ({
+  isMaxMemberCountCustom,
+  errors,
+  register,
+}: {
+  isMaxMemberCountCustom: boolean;
+} & _DefaultFieldProps) => {
+  return (
+    <section className="flex flex-col gap-[1.6rem]">
+      <h2>최대 인원</h2>
+      <div className="flex flex-col gap-[0.5rem]">
+        <div className="inline-flex w-[23rem] flex-wrap gap-[1rem]">
+          {MAX_MEMBER_COUNT_OPTIONS.map(option => (
+            <RadioButton
+              key={option.value}
+              value={option.value}
+              label={option.label}
+              {...register?.('maxMemberCount', {
+                required: '모임 최대 인원을 선택해 주세요',
+              })}
+            />
+          ))}
+        </div>
+        <ErrorMessage>{errors?.maxMemberCount?.message}</ErrorMessage>
+      </div>
+      {isMaxMemberCountCustom && (
+        <div className="flex flex-col gap-[0.5rem]">
+          <Input
+            type="number"
+            placeholder="1000명 이상의 인원은 제한 없음을 선택해주세요"
+            {...register?.('customMemberCount', {
+              required: {
+                value: isMaxMemberCountCustom,
+                message: '모임 최대 인원을 입력해주세요',
+              },
+              min: { value: 2, message: '모임 인원은 최소 2명부터 가능해요' },
+              max: { value: 1000, message: '1000 이하의 값을 입력해주세요' },
+            })}
+          />
+          <ErrorMessage>{errors?.customMemberCount?.message}</ErrorMessage>
+        </div>
+      )}
+    </section>
+  );
+};
+
+const PickDateField = ({
+  selectedStartDate,
+  errors,
+  register,
+}: {
+  selectedStartDate: string;
+} & _DefaultFieldProps) => {
+  return (
+    <>
+      <section className="flex flex-col gap-[0.5rem]">
+        <div className="flex items-center justify-between">
+          <h2>모임 시작일</h2>
+          <DatePicker
+            {...register?.('startDate', {
+              required: '모임 시작일을 선택해주세요',
+              min: {
+                value: getTodayDate(),
+                message: '모임 시작일은 오늘 혹은 그 이후로 선택해주세요',
+              },
+            })}
+          />
+        </div>
+        <ErrorMessage>{errors?.startDate?.message}</ErrorMessage>
+      </section>
+      <section className="flex flex-col gap-[0.5rem]">
+        <div className="flex items-center justify-between">
+          <h2>모임 종료일</h2>
+          <DatePicker
+            {...register?.('endDate', {
+              required: '모임 종료일을 선택해주세요',
+              min: {
+                value: selectedStartDate,
+                message: '모임 종료일은 시작일보다 늦어야해요',
+              },
+            })}
+          />
+        </div>
+        <ErrorMessage>{errors?.endDate?.message}</ErrorMessage>
+      </section>
+    </>
+  );
+};
+
+const SwitchIsPublicField = ({ register }: _DefaultFieldProps) => {
+  return (
+    <section className="flex items-start justify-between">
+      <div className="flex min-w-0 flex-col gap-[0.3rem]">
+        <h2>댓글 공개 여부</h2>
+        <p className="text-xs text-placeholder">
+          모임에 가입하지 않은 사람도 댓글을 볼 수 있어요.
+        </p>
+      </div>
+      <Switch {...register?.('isPublic')} />
+    </section>
+  );
+};

--- a/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/funnel/SetUpDetailStep.tsx
@@ -7,6 +7,7 @@ import {
 import type { APICreateGroup } from '@/types/group';
 
 import { getTodayDate } from '@/utils/date';
+import { MAX_MEMBER_COUNT_OPTIONS } from '@/constants';
 
 import BottomActionButton from '@/v1/base/BottomActionButton';
 import DatePicker from '@/v1/base/DatePicker';
@@ -32,15 +33,6 @@ interface SetUpDetailStepValues
   maxMemberCount: string | number;
   customMemberCount: string | number;
 }
-
-const MAX_MEMBER_COUNT_OPTIONS = [
-  { label: '제한없음', value: 9999 },
-  { label: '50명', value: 50 },
-  { label: '100명', value: 100 },
-  { label: '200명', value: 200 },
-  { label: '500명', value: 500 },
-  { label: '직접 입력', value: 'custom' },
-] as const;
 
 const SetUpDetailStep = ({
   // FIXME: goToEnterTitleStep,


### PR DESCRIPTION
# 구현 내용
모임 상세 퍼널을 구현했습니다

# 스크린샷

<!-- 없는 경우 생략한다. -->

# pr 포인트
### RadioButton 컴포넌트 수정
- __이제 `RadioButton` 컴포넌트가 `label` props를 받습니다 1fbbf18be6c3cdaa85cc156f529ac53c5d90a214__
이전에 value값으로만 라디오 버튼의 UI를 표현하던 부분을 개선했습니다.
`label` props를 통해 라디오 버튼의 UI를 표현합니다.
`label` props를 받지 않으면 이전과 동일하게 `value`값을 통해 UI를 표현합니다.

### 모임 상세 스텝 작성
- __모임 상세 스텝을 작성했습니다__
특이사항: formValues에 `maxMemberCount`이외에 `customMemberCount`가 추가되었습니다.
특이사항: formValues 내부의 `maxMemberCount`와 `customMemberCount`는 API 요청 타입과는 다르게 `string | number` 타입입니다.

# 관련 이슈

- Close #553 
