### PR TITLE
[#562] [모임 생성] 모임 이름 퍼널

### DIFF
--- a/src/stories/bookGroup/create/funnel/EnterTitleStep.stories.tsx
+++ b/src/stories/bookGroup/create/funnel/EnterTitleStep.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { appLayoutMeta } from '@/stories/meta';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import {
+  EnterTitleStep,
+  type EnterTitleStepValues,
+} from '@/v1/bookGroup/create/steps/EnterTitleStep';
+
+const meta: Meta<typeof EnterTitleStep> = {
+  title: 'bookGroup/create/steps/EnterTitleStep',
+  component: EnterTitleStep,
+  ...appLayoutMeta,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EnterTitleStep>;
+
+const EnterTitleForm = () => {
+  const methods = useForm<EnterTitleStepValues>({
+    mode: 'all',
+    defaultValues: {
+      title: '',
+    },
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <EnterTitleStep />
+      </form>
+    </FormProvider>
+  );
+};
+
+export const Default: Story = {
+  render: () => <EnterTitleForm />,
+};

--- a/src/v1/bookGroup/create/steps/EnterTitleStep/EnterTitleStep.tsx
+++ b/src/v1/bookGroup/create/steps/EnterTitleStep/EnterTitleStep.tsx
@@ -1,0 +1,36 @@
+import { useFormContext } from 'react-hook-form';
+
+import BottomActionButton from '@/v1/base/BottomActionButton';
+import { TitleField } from './fields';
+
+interface MoveFunnelStepProps {
+  onNextStep?: () => void;
+}
+
+export interface EnterTitleStepValues {
+  title: string;
+}
+
+const EnterTitleStep = ({ onNextStep }: MoveFunnelStepProps) => {
+  const { handleSubmit } = useFormContext<EnterTitleStepValues>();
+
+  return (
+    <article>
+      <section className="flex flex-col gap-[1.5rem]">
+        <h2 className="text-lg font-bold text-black-700">
+          독서모임 이름을 적어주세요
+        </h2>
+        <TitleField name="title" />
+      </section>
+
+      <BottomActionButton
+        type="submit"
+        onClick={handleSubmit(() => onNextStep?.())}
+      >
+        다음
+      </BottomActionButton>
+    </article>
+  );
+};
+
+export default EnterTitleStep;

--- a/src/v1/bookGroup/create/steps/EnterTitleStep/fields/TitleField.tsx
+++ b/src/v1/bookGroup/create/steps/EnterTitleStep/fields/TitleField.tsx
@@ -1,0 +1,47 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import type { EnterTitleStepValues } from '../EnterTitleStep';
+
+import ErrorMessage from '@/v1/base/ErrorMessage';
+import Input from '@/v1/base/Input';
+import InputLength from '@/v1/base/InputLength';
+
+type DefaultFieldNameProps = {
+  name: keyof EnterTitleStepValues;
+};
+
+const TitleField = ({ name }: DefaultFieldNameProps) => {
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext<EnterTitleStepValues>();
+
+  const titleValue = useWatch({ control, name: name });
+  const titleErrors = errors[name];
+
+  return (
+    <label htmlFor={name} className="flex flex-col gap-[0.5rem]">
+      <Input
+        id={name}
+        placeholder="독서모임을 잘 표현할 수 있는 이름이면 좋아요."
+        error={!!titleErrors}
+        {...register(name, {
+          required: '독서모임 이름을 작성해 주세요',
+          minLength: { value: 2, message: '2글자 이상 입력해주세요' },
+          maxLength: { value: 20, message: '20글자 이하로 입력해주세요' },
+        })}
+      />
+      <div className="flex flex-row-reverse justify-between">
+        <InputLength
+          currentLength={titleValue.length}
+          isError={!!titleErrors}
+          maxLength={20}
+        />
+        <ErrorMessage>{titleErrors?.message}</ErrorMessage>
+      </div>
+    </label>
+  );
+};
+
+export default TitleField;

--- a/src/v1/bookGroup/create/steps/EnterTitleStep/fields/index.ts
+++ b/src/v1/bookGroup/create/steps/EnterTitleStep/fields/index.ts
@@ -1,0 +1,1 @@
+export { default as TitleField } from './TitleField';

--- a/src/v1/bookGroup/create/steps/EnterTitleStep/index.ts
+++ b/src/v1/bookGroup/create/steps/EnterTitleStep/index.ts
@@ -1,0 +1,2 @@
+export type { EnterTitleStepValues } from './EnterTitleStep';
+export { default as EnterTitleStep } from './EnterTitleStep';


### PR DESCRIPTION
# 구현 내용

모임 이름 퍼널 스텝을 구현했습니다

# 스크린샷

https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/e766abf9-dac6-47d7-ad33-fd63e8160250

# pr 포인트
### 타이틀을 입력하는 필드를 `TitleField.tsx`로 분리
- `TitleField.tsx`에는 `useWatch()`를 사용하고있습니다.
- `useWatch()`가 필요한 부분만 `TitleField.tsx`로 분리하여 리랜더링되는 컴포넌트 수를 줄였습니다.

### 새로운 폴더 구조 적용
- 간략한 논의 후에 정하였던 폴더구조로 적용해두었습니다.
<img width="265" alt="image" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/82b14d4e-366e-487b-bf2a-773804783224">


# 관련 이슈

- Close #562 