### PR TITLE
[#561] [모임 생성] 모임 상세 퍼널 개선

### DIFF
--- a/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
@@ -23,22 +23,44 @@ const SetUpDetailForm = () => {
   const methods = useForm<SetUpDetailStepValues>({
     mode: 'all',
     defaultValues: {
+      title: '',
       book: {
         bookId: 23,
       },
-      title: '',
       introduce: '',
       maxMemberCount: '',
+      customMemberCount: '',
       startDate: getTodayDate(),
       endDate: '',
       isPublic: false,
     },
   });
 
+  const onNextStep = () => {
+    const {
+      book,
+      title,
+      introduce,
+      maxMemberCount,
+      customMemberCount,
+      startDate,
+      endDate,
+      isPublic,
+    } = methods.getValues();
+    alert(`bookId: ${book.bookId},
+      title: ${title},
+      introduce: ${introduce},
+      maxMemberCount: ${maxMemberCount},
+      customMemberCount: ${customMemberCount},
+      startDate: ${startDate},
+      endDate: ${endDate},
+      isPublic: ${isPublic}`);
+  };
+
   return (
     <FormProvider {...methods}>
       <form>
-        <SetUpDetailStep />
+        <SetUpDetailStep onNextStep={onNextStep} />
       </form>
     </FormProvider>
   );

--- a/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
@@ -1,13 +1,16 @@
+import { appLayoutMeta } from '@/stories/meta';
+import { Meta, StoryObj } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
-import type { APICreateGroup } from '@/types/group';
+
 import { getTodayDate } from '@/utils/date';
 
-import { SetUpDetailStep } from '@/v1/bookGroup/create/funnel';
-import { Meta, StoryObj } from '@storybook/react';
-import { appLayoutMeta } from '@/stories/meta';
+import {
+  SetUpDetailStep,
+  type SetUpDetailStepValues,
+} from '@/v1/bookGroup/create/steps/SetUpDetailStep';
 
 const meta: Meta<typeof SetUpDetailStep> = {
-  title: 'bookGroup/funnel/SetUpDetailStep',
+  title: 'bookGroup/create/steps/SetUpDetailStep',
   component: SetUpDetailStep,
   ...appLayoutMeta,
 };
@@ -15,24 +18,20 @@ const meta: Meta<typeof SetUpDetailStep> = {
 export default meta;
 
 type Story = StoryObj<typeof SetUpDetailStep>;
-interface FunnelFormValues extends APICreateGroup {
-  customMemberCount: string | number;
-}
 
 const SetUpDetailForm = () => {
-  const methods = useForm<FunnelFormValues>({
+  const methods = useForm<SetUpDetailStepValues>({
     mode: 'all',
     defaultValues: {
-      bookId: 23,
+      book: {
+        bookId: 23,
+      },
       title: '',
       introduce: '',
-      maxMemberCount: 9999,
+      maxMemberCount: '',
       startDate: getTodayDate(),
       endDate: '',
       isPublic: false,
-      hasJoinPasswd: false,
-      joinQuestion: '',
-      joinPasswd: '',
     },
   });
 

--- a/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
@@ -47,7 +47,8 @@ const SetUpDetailForm = () => {
       endDate,
       isPublic,
     } = methods.getValues();
-    alert(`bookId: ${book.bookId},
+    alert(`
+      bookId: ${book.bookId},
       title: ${title},
       introduce: ${introduce},
       maxMemberCount: ${maxMemberCount},

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,6 +31,8 @@
     max-width: 43rem;
     margin: 0 auto !important;
   }
+
+  /* DatePicker Calendar 스타일링 */
   input[type='date']::-webkit-calendar-picker-indicator {
     background-image: none;
     position: absolute;
@@ -41,6 +43,17 @@
     margin: 0;
     padding: 0;
     cursor: pointer;
+  }
+
+  /* Input type=number 버튼 제거 */
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  /* FireFox */
+  input[type='number'] {
+    -moz-appearance: textfield;
   }
 }
 

--- a/src/v1/bookGroup/create/funnel/index.ts
+++ b/src/v1/bookGroup/create/funnel/index.ts
@@ -1,2 +1,2 @@
 // export { default as SelectBookStep } from './SelectBookStep';
-export { default as SetUpDetailStep } from './SetUpDetailStep';
+export { default as SetUpDetailStep } from '../steps/SetUpDetailStep/SetUpDetailStep';

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -34,7 +34,6 @@ export interface SetUpDetailStepValues
     'bookId' | 'title' | 'introduce' | 'startDate' | 'endDate' | 'isPublic'
   > {
   book: SearchedBookWithId;
-  queryKeyword: string;
   maxMemberCount: string;
   customMemberCount: string;
 }
@@ -235,7 +234,7 @@ const PickStartDateField = ({ name }: SetUpDetailFieldProps) => {
               message: '모임 시작일은 오늘 혹은 그 이후로 선택해주세요',
             },
             max: {
-              value: endDate || '9999-12-31',
+              value: endDate,
               message: '모임 시작일은 종료일 보다 빨라야해요',
             },
           })}

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -1,10 +1,10 @@
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import type { APICreateGroup } from '@/types/group';
 import type { SearchedBookWithId } from '@/types/book';
+import type { APICreateGroup } from '@/types/group';
 
-import { getTodayDate } from '@/utils/date';
 import { MAX_MEMBER_COUNT_OPTIONS } from '@/constants';
+import { getTodayDate } from '@/utils/date';
 
 import BottomActionButton from '@/v1/base/BottomActionButton';
 import DatePicker from '@/v1/base/DatePicker';
@@ -14,7 +14,7 @@ import InputLength from '@/v1/base/InputLength';
 import RadioButton from '@/v1/base/RadioButton';
 import Switch from '@/v1/base/Switch';
 import TextArea from '@/v1/base/TextArea';
-import BookInfoCard from '../../BookInfoCard';
+import BookInfoCard from '@/v1/bookGroup/BookInfoCard';
 
 interface MoveFunnelStepProps {
   onPrevStep?: () => void;
@@ -28,7 +28,7 @@ interface MoveFunnelStepProps {
  * goToSelectBookStep 받도록 수정
  */
 
-interface SetUpDetailStepValues
+export interface SetUpDetailStepValues
   extends Pick<
     APICreateGroup,
     'bookId' | 'title' | 'introduce' | 'startDate' | 'endDate' | 'isPublic'

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/index.ts
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/index.ts
@@ -1,0 +1,2 @@
+export type { SetUpDetailStepValues } from './SetUpDetailStep';
+export { default as SetUpDetailStep } from './SetUpDetailStep';


### PR DESCRIPTION
# 구현 내용

모임 상세 퍼널 개선

# pr 포인트
### global.css 수정사항
- input 컴포넌트의 type이 number일 경우 오른쪽에 나타나는 버튼을 숨겼습니다.

### 모임상세 스텝 수정사항 및 개선사항
- CustomMemberCountField의 Input 컴포넌트 after 스타일 추가
- watch를 `useWatch()`로 대체
- SelectedBookInfoField에 `book.bookId`를 받을 수 있도록 수정

# 관련 이슈

- Close #561 
