### PR TITLE
[#563] [모임 생성] 모임 가입문제 퍼널

### DIFF
--- a/src/stories/bookGroup/create/steps/SelectJoinTypeStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SelectJoinTypeStep.stories.tsx
@@ -4,7 +4,7 @@ import { appLayoutMeta } from '@/stories/meta';
 
 import {
   SelectJoinTypeStep,
-  SelectJoinFormValue,
+  SelectJoinTypeStepFormValues,
 } from '@/v1/bookGroup/create/steps/SelectJoinTypeStep';
 
 const meta: Meta<typeof SelectJoinTypeStep> = {
@@ -17,8 +17,8 @@ export default meta;
 
 type Story = StoryObj<typeof SelectJoinTypeStep>;
 
-const RenderSelectBookStep = () => {
-  const methods = useForm<SelectJoinFormValue>({
+const RenderSelectJoinTypeStep = () => {
+  const methods = useForm<SelectJoinTypeStepFormValues>({
     defaultValues: {
       hasJoinPasswd: 'false',
     },
@@ -42,5 +42,5 @@ const RenderSelectBookStep = () => {
 };
 
 export const Default: Story = {
-  render: () => <RenderSelectBookStep />,
+  render: () => <RenderSelectJoinTypeStep />,
 };

--- a/src/stories/bookGroup/create/steps/SelectJoinTypeStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SelectJoinTypeStep.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { appLayoutMeta } from '@/stories/meta';
+
+import {
+  SelectJoinTypeStep,
+  SelectJoinFormValue,
+} from '@/v1/bookGroup/create/steps/SelectJoinTypeStep';
+
+const meta: Meta<typeof SelectJoinTypeStep> = {
+  title: 'bookGroup/create/steps/SelectJoinTypeStep',
+  component: SelectJoinTypeStep,
+  ...appLayoutMeta,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SelectJoinTypeStep>;
+
+const RenderSelectBookStep = () => {
+  const methods = useForm<SelectJoinFormValue>({
+    defaultValues: {
+      hasJoinPasswd: 'false',
+    },
+    mode: 'all',
+  });
+
+  const onSubmit = () => {
+    const { hasJoinPasswd, joinPasswd, joinQuestion } = methods.getValues();
+    alert(
+      `가입 문제 유무: ${hasJoinPasswd}\n가입 문제: ${joinQuestion}\n정답: ${joinPasswd}`
+    );
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <SelectJoinTypeStep onSubmit={onSubmit} />
+      </form>
+    </FormProvider>
+  );
+};
+
+export const Default: Story = {
+  render: () => <RenderSelectBookStep />,
+};

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
@@ -27,11 +27,13 @@ const SelectJoinTypeStep = ({ onSubmit }: MoveFunnelStepProps) => {
       <h2 className="mb-[3rem] text-lg font-bold">가입은 어떻게 받을까요?</h2>
 
       <section className="flex flex-col gap-[2rem]">
-        <JoinTypeFieldset name="hasJoinPasswd" />
+        <JoinTypeFieldset>
+          <JoinTypeFieldset.RadioCardField name="hasJoinPasswd" />
+        </JoinTypeFieldset>
 
         <JoinPasswordFieldset joinTypeFieldName="hasJoinPasswd">
-          <JoinPasswordFieldset.Question name="joinQuestion" />
-          <JoinPasswordFieldset.Answer name="joinPasswd" />
+          <JoinPasswordFieldset.QuestionField name="joinQuestion" />
+          <JoinPasswordFieldset.AnswerField name="joinPasswd" />
         </JoinPasswordFieldset>
       </section>
 

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
@@ -1,0 +1,48 @@
+import { useFormContext } from 'react-hook-form';
+
+import BottomActionButton from '@/v1/base/BottomActionButton';
+
+import { JoinPasswordFieldset, JoinTypeFieldset } from './fields';
+
+interface MoveFunnelStepProps {
+  onPrevStep?: () => void;
+  onNextStep?: () => void;
+  onSubmit?: () => void;
+}
+
+export type JoinTypeStepFormValues = {
+  hasJoinPasswd: 'true' | 'false';
+  joinQuestion?: string;
+  joinPasswd?: string;
+};
+
+export type JoinTypeStepFieldName = keyof JoinTypeStepFormValues;
+export type JoinTypeStepFieldProp = { name: JoinTypeStepFieldName };
+
+const SelectJoinTypeStep = ({ onSubmit }: MoveFunnelStepProps) => {
+  const { handleSubmit } = useFormContext<JoinTypeStepFormValues>();
+
+  return (
+    <article>
+      <h2 className="mb-[3rem] text-lg font-bold">가입은 어떻게 받을까요?</h2>
+
+      <section className="flex flex-col gap-[2rem]">
+        <JoinTypeFieldset name="hasJoinPasswd" />
+
+        <JoinPasswordFieldset joinTypeFieldName="hasJoinPasswd">
+          <JoinPasswordFieldset.Question name="joinQuestion" />
+          <JoinPasswordFieldset.Answer name="joinPasswd" />
+        </JoinPasswordFieldset>
+      </section>
+
+      <BottomActionButton
+        type="submit"
+        onClick={onSubmit && handleSubmit(onSubmit)}
+      >
+        독서모임 만들기
+      </BottomActionButton>
+    </article>
+  );
+};
+
+export default SelectJoinTypeStep;

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
@@ -1,0 +1,119 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import ErrorMessage from '@/v1/base/ErrorMessage';
+import Input from '@/v1/base/Input';
+import InputLength from '@/v1/base/InputLength';
+
+import {
+  JoinTypeStepFieldName,
+  JoinTypeStepFormValues,
+  JoinTypeStepFieldProp,
+} from '../SelectJoinTypeStep';
+
+type JoinPasswordFieldsetProps = {
+  joinTypeFieldName: JoinTypeStepFieldName;
+  children?: React.ReactNode;
+};
+
+const JoinPasswordFieldset = ({
+  joinTypeFieldName,
+  children,
+}: JoinPasswordFieldsetProps) => {
+  const { control } = useFormContext<JoinTypeStepFormValues>();
+  const hasJoinPassword = useWatch({ control, name: joinTypeFieldName });
+
+  const shouldRender = hasJoinPassword === 'true';
+
+  return (
+    <>
+      {shouldRender && (
+        <fieldset className="flex flex-col gap-[1.5rem]">{children}</fieldset>
+      )}
+    </>
+  );
+};
+
+const JoinQuestionField = ({ name }: JoinTypeStepFieldProp) => {
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext<JoinTypeStepFormValues>();
+
+  const joinQuestion = useWatch({ control, name });
+
+  const questionLength = joinQuestion?.length;
+  const error = errors[name];
+
+  return (
+    <label className="flex flex-col gap-[0.5rem]">
+      <p>가입 문제</p>
+      <Input
+        placeholder="모임에 가입하기 위한 적절한 문제를 작성해주세요"
+        {...register(name, {
+          required: '1 ~ 30글자의 가입 문제가 필요해요',
+          maxLength: {
+            value: 30,
+            message: '1 ~ 30글자의 가입 문제를 작성해주세요',
+          },
+        })}
+        error={!!error}
+      />
+      <div className="flex flex-row-reverse justify-between">
+        <InputLength
+          currentLength={questionLength}
+          isError={!!error}
+          maxLength={30}
+        />
+        <ErrorMessage>{error?.message}</ErrorMessage>
+      </div>
+    </label>
+  );
+};
+
+const JoinAnswerField = ({ name }: JoinTypeStepFieldProp) => {
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext<JoinTypeStepFormValues>();
+
+  const joinPasswd = useWatch({ control, name });
+
+  const passwordLength = joinPasswd?.length;
+  const error = errors[name];
+
+  return (
+    <label className="flex flex-col gap-[0.5rem]">
+      <p>정답</p>
+      <Input
+        placeholder="띄어쓰기 없이 정답을 작성해주세요"
+        {...register(name, {
+          required: '띄어쓰기 없이 10자 이하의 정답이 필요해요',
+          maxLength: {
+            value: 10,
+            message: '띄어쓰기 없이 10자 이하의 정답을 작성해주세요,',
+          },
+          pattern: {
+            value: /^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]+$/,
+            message: '띄어쓰기 없이 한글, 영어, 숫자만 입력할 수 있어요',
+          },
+        })}
+        error={!!error}
+      />
+      <div className="flex flex-row-reverse justify-between">
+        <InputLength
+          currentLength={passwordLength}
+          isError={!!error}
+          maxLength={10}
+        />
+        <ErrorMessage>{error?.message}</ErrorMessage>
+      </div>
+    </label>
+  );
+};
+
+JoinPasswordFieldset.Question = JoinQuestionField;
+JoinPasswordFieldset.Answer = JoinAnswerField;
+
+export default JoinPasswordFieldset;

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import ErrorMessage from '@/v1/base/ErrorMessage';
@@ -12,13 +13,12 @@ import {
 
 type JoinPasswordFieldsetProps = {
   joinTypeFieldName: JoinTypeStepFieldName;
-  children?: React.ReactNode;
 };
 
 const JoinPasswordFieldset = ({
   joinTypeFieldName,
   children,
-}: JoinPasswordFieldsetProps) => {
+}: PropsWithChildren<JoinPasswordFieldsetProps>) => {
   const { control } = useFormContext<JoinTypeStepFormValues>();
   const hasJoinPassword = useWatch({ control, name: joinTypeFieldName });
 
@@ -89,10 +89,10 @@ const JoinAnswerField = ({ name }: JoinTypeStepFieldProp) => {
       <Input
         placeholder="띄어쓰기 없이 정답을 작성해주세요"
         {...register(name, {
-          required: '띄어쓰기 없이 10자 이하의 정답이 필요해요',
+          required: '띄어쓰기 없이 10글자 이하의 정답이 필요해요',
           maxLength: {
             value: 10,
-            message: '띄어쓰기 없이 10자 이하의 정답을 작성해주세요,',
+            message: '띄어쓰기 없이 10글자 이하의 정답을 작성해주세요,',
           },
           pattern: {
             value: /^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]+$/,
@@ -113,7 +113,7 @@ const JoinAnswerField = ({ name }: JoinTypeStepFieldProp) => {
   );
 };
 
-JoinPasswordFieldset.Question = JoinQuestionField;
-JoinPasswordFieldset.Answer = JoinAnswerField;
+JoinPasswordFieldset.QuestionField = JoinQuestionField;
+JoinPasswordFieldset.AnswerField = JoinAnswerField;
 
 export default JoinPasswordFieldset;

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeFieldset.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeFieldset.tsx
@@ -1,0 +1,31 @@
+import { useFormContext } from 'react-hook-form';
+
+import {
+  JoinTypeStepFormValues,
+  JoinTypeStepFieldProp,
+} from '../SelectJoinTypeStep';
+
+import JoinTypeRadioCard from './JoinTypeRadioCard';
+
+const JoinTypeFieldset = ({ name }: JoinTypeStepFieldProp) => {
+  const { register } = useFormContext<JoinTypeStepFormValues>();
+
+  return (
+    <fieldset className="flex flex-col gap-[1rem]">
+      <JoinTypeRadioCard
+        {...register(name)}
+        id="no-password"
+        value="false"
+        label="문제 없이 가입할 수 있어요"
+      />
+      <JoinTypeRadioCard
+        {...register(name)}
+        id="has-password"
+        value="true"
+        label="문제를 맞춰야 모임에 가입할 수 있어요"
+      />
+    </fieldset>
+  );
+};
+
+export default JoinTypeFieldset;

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeFieldset.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeFieldset.tsx
@@ -7,11 +7,15 @@ import {
 
 import JoinTypeRadioCard from './JoinTypeRadioCard';
 
-const JoinTypeFieldset = ({ name }: JoinTypeStepFieldProp) => {
+const JoinTypeFieldset = ({ children }: { children?: React.ReactNode }) => {
+  return <fieldset className="flex flex-col gap-[1rem]">{children}</fieldset>;
+};
+
+const RadioCardField = ({ name }: JoinTypeStepFieldProp) => {
   const { register } = useFormContext<JoinTypeStepFormValues>();
 
   return (
-    <fieldset className="flex flex-col gap-[1rem]">
+    <>
       <JoinTypeRadioCard
         {...register(name)}
         id="no-password"
@@ -24,8 +28,10 @@ const JoinTypeFieldset = ({ name }: JoinTypeStepFieldProp) => {
         value="true"
         label="문제를 맞춰야 모임에 가입할 수 있어요"
       />
-    </fieldset>
+    </>
   );
 };
+
+JoinTypeFieldset.RadioCardField = RadioCardField;
 
 export default JoinTypeFieldset;

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeRadioCard.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinTypeRadioCard.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, InputHTMLAttributes, Ref } from 'react';
+
+const BASE_CLASSES =
+  'flex h-[8rem] w-full cursor-pointer items-center justify-between rounded-[0.5rem] border-[0.1rem] bg-white px-[2.5rem] text-black-600 text-md';
+
+const JoinTypeRadioCard = (
+  {
+    id,
+    value,
+    label,
+    ...props
+  }: Omit<InputHTMLAttributes<HTMLInputElement>, 'className' | 'type'> & {
+    label?: string;
+  },
+  ref: Ref<HTMLInputElement>
+) => {
+  const inputId = id || 'radio-card';
+
+  return (
+    <div>
+      <input
+        type="radio"
+        id={inputId}
+        value={value}
+        className="peer hidden"
+        ref={ref}
+        {...props}
+      />
+      <label
+        className={`${BASE_CLASSES} after:h-[2.4rem] peer-checked:border-main-900 peer-checked:bg-main-900/[0.05] peer-checked:text-[#FF8B00] peer-checked:after:content-check`}
+        htmlFor={inputId}
+      >
+        <p>{label}</p>
+      </label>
+    </div>
+  );
+};
+
+export default forwardRef(JoinTypeRadioCard);

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/index.ts
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/index.ts
@@ -1,0 +1,2 @@
+export { default as JoinTypeFieldset } from './JoinTypeFieldset';
+export { default as JoinPasswordFieldset } from './JoinPasswordFieldset';

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/index.ts
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/index.ts
@@ -1,2 +1,2 @@
-export type { JoinTypeStepFormValues as SelectJoinFormValue } from './SelectJoinTypeStep';
+export type { JoinTypeStepFormValues as SelectJoinTypeStepFormValues } from './SelectJoinTypeStep';
 export { default as SelectJoinTypeStep } from './SelectJoinTypeStep';

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/index.ts
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/index.ts
@@ -1,0 +1,2 @@
+export type { JoinTypeStepFormValues as SelectJoinFormValue } from './SelectJoinTypeStep';
+export { default as SelectJoinTypeStep } from './SelectJoinTypeStep';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,6 +122,7 @@ module.exports = {
       },
       content: {
         search: 'url("/icons/search.svg")',
+        check: 'url("/icons/check.svg")',
       },
     },
   },


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
### `SelectJoinTypeStep`
  - 모임 생성 퍼널에서 사용될 `모임 가입문제 스텝` 컴포넌트예요.

### `JoinTypeRadioCard`
  - 모임 가입문제 유무를 선택하기 위한 라디오 카드 뷰를 관리하고 있어요.
  - input radio type의 비제어 컴포넌트예요.

### `JoinTypeFieldset`
  - 모임 가입 문제 유무에 대한 hook form 로직을 관리하는 합성 컴포넌트예요.
  - `JoinPasswordFieldset` 컴포넌트와 추상화 레벨을 맞추어 코드 가독성을 높이고 싶어서 합성 컴포넌트 형태로 구현하게 되었어요.
  - 하위 컴포넌트 `RadioCardField`에 name prop을 전달하여 form에 register할 수 있어요.

### `JoinPasswordFieldset`
  - 모임 가입 문제 있음을 선택한 경우, 가입 문제와 정답 field를 렌더링하는 로직을 담고 있어요.
  - 하위 컴포넌트 `AnswerField`, `QuestionField` 각각에 name prop을 전달하여 form에 register할 수 있어요.

<!-- - ex) 결제 기능 구현 -->

# 스크린샷

<img width="600" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/920fbbae-aae1-44c8-80fa-825c8f46f294" />



<!-- 없는 경우 생략한다. -->

# pr 포인트
- 하위 field들이 모두 FormValueType에 의존하고 있어서 재사용성이 높은 구조는 아니라고 생각돼요.
- 하지만 form context를 사용하고 있는만큼 리렌더링을 최소화하고, 최상단인 Step 컴포넌트에서 구조를 파악하기 쉬운 방향으로 작성하려고 노력하다보니 합성 컴포넌트 형태로 구현하게 되었어요. 고민해보고 더 나은 방향이 떠오른다면 추후 리팩토링해볼게요! 🥲

<!-- - ex) XX를 중점적으로 봐주세요. -->


# 관련 이슈

- Close #563 <!--이슈번호-->
