### PR TITLE
[#559] BookInfoCard 컴포넌트 수정 및 goToBookSelectStep 이벤트 추가

### DIFF
--- a/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
+++ b/src/stories/bookGroup/create/steps/SetUpDetailStep.stories.tsx
@@ -61,7 +61,10 @@ const SetUpDetailForm = () => {
   return (
     <FormProvider {...methods}>
       <form>
-        <SetUpDetailStep onNextStep={onNextStep} />
+        <SetUpDetailStep
+          goToSelectBookStep={() => alert('goToSelectBookStep')}
+          onNextStep={onNextStep}
+        />
       </form>
     </FormProvider>
   );

--- a/src/v1/bookGroup/BookInfoCard.tsx
+++ b/src/v1/bookGroup/BookInfoCard.tsx
@@ -3,20 +3,22 @@
 import { Suspense, useEffect, useState } from 'react';
 import Link from 'next/link';
 
+import type { APIBook } from '@/types/book';
 import useBookInfoQuery from '@/queries/book/useBookInfoQuery';
 
-import { IconArrowLeft, IconBookPlus, IconDelete } from '@public/icons';
+import { IconArrowLeft, IconDelete } from '@public/icons';
 import BookCover from '@/v1/book/BookCover';
-import { APIBook } from '@/types/book';
 
 const BookInfoCard = ({
   bookId,
   removable = false,
   onBookIdChange: _onBookIdChange,
+  onBookIdRemove,
 }: {
   bookId?: number;
   removable?: boolean;
   onBookIdChange?: (id: APIBook['bookId']) => void;
+  onBookIdRemove?: () => void;
 }) => {
   const [id, setId] = useState<typeof bookId | null>(bookId);
 
@@ -24,18 +26,20 @@ const BookInfoCard = ({
     setId(bookId);
   }, [bookId]);
 
-  const handleBookSelect = () => {
-    // TODO: 도서 선택 UI 제공 후 선택된 도서로 id 변경
-    // setId(23);
-    // onBookIdChange?.(23);
-  };
+  // TODO: 추후 EmptyBookInfoCard 컴포넌트를 쓰게되면 활용
+  // const handleBookSelect = () => {
+  //   TODO: 도서 선택 UI 제공 후 선택된 도서로 id 변경
+  //   setId(23);
+  //   onBookIdChange?.(23);
+  // };
 
   const handleBookInfoRemove = () => {
+    onBookIdRemove?.();
     setId(null);
   };
 
   if (!id) {
-    return <EmptyBookInfoCard onBookSelect={handleBookSelect} />;
+    return <BookInfoCardSkeleton />;
   }
 
   return (
@@ -83,19 +87,20 @@ const BookInfoContent = ({
   );
 };
 
-const EmptyBookInfoCard = ({ onBookSelect }: { onBookSelect?: () => void }) => {
-  return (
-    <div
-      className="flex min-h-[12.8rem] w-full cursor-pointer flex-col items-center justify-center gap-[1rem] rounded-[0.5rem] border-[0.05rem] border-cancel shadow-bookcard"
-      onClick={onBookSelect}
-    >
-      <IconBookPlus className="h-[2rem] w-[2rem] fill-placeholder" />
-      <p className="text-xs text-placeholder">
-        독서모임에 사용할 책을 선택해주세요
-      </p>
-    </div>
-  );
-};
+// TODO: 이후 퍼널 Step의 이동 로직이 변경되면 활용될 컴포넌트
+// const EmptyBookInfoCard = ({ onBookSelect }: { onBookSelect?: () => void }) => {
+//   return (
+//     <div
+//       className="flex min-h-[12.8rem] w-full cursor-pointer flex-col items-center justify-center gap-[1rem] rounded-[0.5rem] border-[0.05rem] border-cancel shadow-bookcard"
+//       onClick={onBookSelect}
+//     >
+//       <IconBookPlus className="h-[2rem] w-[2rem] fill-placeholder" />
+//       <p className="text-xs text-placeholder">
+//         독서모임에 사용할 책을 선택해주세요
+//       </p>
+//     </div>
+//   );
+// };
 
 const BookInfoCardSkeleton = () => {
   return (

--- a/src/v1/bookGroup/BookInfoCard.tsx
+++ b/src/v1/bookGroup/BookInfoCard.tsx
@@ -13,12 +13,12 @@ const BookInfoCard = ({
   bookId,
   removable = false,
   onBookIdChange: _onBookIdChange,
-  onBookIdRemove,
+  onBookRemove,
 }: {
   bookId?: number;
   removable?: boolean;
   onBookIdChange?: (id: APIBook['bookId']) => void;
-  onBookIdRemove?: () => void;
+  onBookRemove?: () => void;
 }) => {
   const [id, setId] = useState<typeof bookId | null>(bookId);
 
@@ -34,7 +34,7 @@ const BookInfoCard = ({
   // };
 
   const handleBookInfoRemove = () => {
-    onBookIdRemove?.();
+    onBookRemove?.();
     setId(null);
   };
 

--- a/src/v1/bookGroup/create/funnel/SelectBookStep.tsx
+++ b/src/v1/bookGroup/create/funnel/SelectBookStep.tsx
@@ -47,7 +47,7 @@ const SelectBookStep = ({ onNextStep }: MoveFunnelStepProps) => {
         className="mb-[1rem]"
         defaultValue={keyword}
         onChange={event => debouncedSetKeyword(event.target.value)}
-        onKeyDown={event => handleEnterKeyDown(event)}
+        onKeyDown={handleEnterKeyDown}
       />
 
       <Suspense fallback={<Loading fullpage />}>

--- a/src/v1/bookGroup/create/funnel/SelectBookStep.tsx
+++ b/src/v1/bookGroup/create/funnel/SelectBookStep.tsx
@@ -30,6 +30,12 @@ const SelectBookStep = ({ onNextStep }: MoveFunnelStepProps) => {
   const [keyword, setKeyword] = useState(keywordValue || '');
   const debouncedSetKeyword = debounce(setKeyword, 500);
 
+  const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.code === 'Enter') e.preventDefault();
+
+    return;
+  };
+
   return (
     <article className="relative flex w-full flex-col gap-[1rem]">
       <h2 className="text-lg font-bold">어떤 책으로 독서모임을 시작할까요?</h2>
@@ -41,6 +47,7 @@ const SelectBookStep = ({ onNextStep }: MoveFunnelStepProps) => {
         className="mb-[1rem]"
         defaultValue={keyword}
         onChange={event => debouncedSetKeyword(event.target.value)}
+        onKeyDown={event => handleEnterKeyDown(event)}
       />
 
       <Suspense fallback={<Loading fullpage />}>

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -29,7 +29,6 @@ interface SetUpDetailStepProps extends MoveFunnelStepProps {
 /**
  * @todo
  * Field 컴포넌트 분리
- * goToSelectBookStep 받도록 수정
  */
 
 export interface SetUpDetailStepValues
@@ -128,7 +127,7 @@ const SelectedBookInfoField = ({
 }) => {
   const { reset } = useFormContext<SetUpDetailStepValues>();
 
-  const handleBookIdRemove = () => {
+  const handleBookRemove = () => {
     onClickRemove?.();
     reset({ book: undefined });
 
@@ -139,7 +138,7 @@ const SelectedBookInfoField = ({
     <section>
       <BookInfoCard
         bookId={bookId}
-        onBookIdRemove={handleBookIdRemove}
+        onBookRemove={handleBookRemove}
         removable={true}
       />
     </section>

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -52,7 +52,7 @@ const SetUpDetailStep = ({
       <TitleField name={'title'} />
       <SelectedBookInfoField
         bookId={getValues('book.bookId')}
-        onClickRemove={goToSelectBookStep}
+        onRemoveButtonClick={goToSelectBookStep}
       />
       <IntroduceField name={'introduce'} />
 
@@ -120,15 +120,15 @@ const TitleField = ({ name }: SetUpDetailFieldProps) => {
 
 const SelectedBookInfoField = ({
   bookId,
-  onClickRemove,
+  onRemoveButtonClick,
 }: {
   bookId?: number;
-  onClickRemove?: () => void;
+  onRemoveButtonClick?: () => void;
 }) => {
   const { reset } = useFormContext<SetUpDetailStepValues>();
 
   const handleBookRemove = () => {
-    onClickRemove?.();
+    onRemoveButtonClick?.();
     reset({ book: undefined });
 
     return;

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -22,6 +22,10 @@ interface MoveFunnelStepProps {
   onSubmit?: () => void;
 }
 
+interface SetUpDetailStepProps extends MoveFunnelStepProps {
+  goToSelectBookStep?: () => void;
+}
+
 /**
  * @todo
  * Field 컴포넌트 분리
@@ -39,15 +43,18 @@ export interface SetUpDetailStepValues
 }
 
 const SetUpDetailStep = ({
-  // goToSelectBookStep,
+  goToSelectBookStep,
   onNextStep,
-}: MoveFunnelStepProps) => {
+}: SetUpDetailStepProps) => {
   const { handleSubmit, getValues } = useFormContext<SetUpDetailStepValues>();
 
   return (
     <article className="flex flex-col gap-[3.2rem] overflow-y-scroll pb-[7rem]">
       <TitleField name={'title'} />
-      <SelectedBookInfoField bookId={getValues('book')?.bookId} />
+      <SelectedBookInfoField
+        bookId={getValues('book.bookId')}
+        onClickRemove={goToSelectBookStep}
+      />
       <IntroduceField name={'introduce'} />
 
       <section className="flex flex-col gap-[1.6rem]">
@@ -112,10 +119,29 @@ const TitleField = ({ name }: SetUpDetailFieldProps) => {
   );
 };
 
-const SelectedBookInfoField = ({ bookId }: { bookId?: number }) => {
+const SelectedBookInfoField = ({
+  bookId,
+  onClickRemove,
+}: {
+  bookId?: number;
+  onClickRemove?: () => void;
+}) => {
+  const { reset } = useFormContext<SetUpDetailStepValues>();
+
+  const handleBookIdRemove = () => {
+    onClickRemove?.();
+    reset({ book: undefined });
+
+    return;
+  };
+
   return (
     <section>
-      <BookInfoCard bookId={bookId} removable={true} />
+      <BookInfoCard
+        bookId={bookId}
+        onBookIdRemove={handleBookIdRemove}
+        removable={true}
+      />
     </section>
   );
 };


### PR DESCRIPTION
# 구현 내용

- `BookInfoCard` 컴포넌트에 `onBookRemove` props를 추가했습니다

- `책 선택 스텝`의 input 태그에서 enter 동작시 submit 되던 현상을 제거했습니다

# 관련 이슈

- Close #559 
