### PR TITLE
[#585] [프로필 페이지] '참여한 모임' 영역 사용자가 모임장인 모임에 마크 추가

### DIFF
--- a/src/app/profile/me/group/page.tsx
+++ b/src/app/profile/me/group/page.tsx
@@ -3,6 +3,7 @@
 import useMyGroupsQuery from '@/queries/group/useMyGroupQuery';
 import { checkAuthentication } from '@/utils/helpers';
 
+import SSRSafeSuspense from '@/components/SSRSafeSuspense';
 import BackButton from '@/v1/base/BackButton';
 import TopNavigation from '@/v1/base/TopNavigation';
 import DetailBookGroupCard from '@/v1/bookGroup/DetailBookGroupCard';
@@ -16,40 +17,16 @@ const UserGroupPage = () => {
         </TopNavigation.LeftItem>
         <TopNavigation.CenterItem>내가 참여한 모임</TopNavigation.CenterItem>
       </TopNavigation>
-      <UserGroupContent />
+      <SSRSafeSuspense fallback={<PageSkeleton />}>
+        <UserGroupContent />
+      </SSRSafeSuspense>
     </>
   );
 };
 
 const UserGroupContent = () => {
   const isAuthenticated = checkAuthentication();
-  const { data, isSuccess } = useMyGroupsQuery({ enabled: isAuthenticated });
-
-  if (!isSuccess) {
-    return (
-      <ul className="flex animate-pulse flex-col gap-[1rem] pt-[2rem]">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <li
-            key={index}
-            className="border-placeholder px-[1.6rem] py-[0.9rem] shadow-bookgroup-card"
-          >
-            <div className="flex gap-[0.5rem] [&>*]:rounded-[0.5rem]">
-              <div className="h-[1.9rem] w-[4.34rem] bg-placeholder" />
-              <div className="h-[1.9rem] w-[4.34rem] bg-placeholder" />
-            </div>
-
-            <div className="flex justify-between gap-[1.5rem] pt-[1rem]">
-              <div className="flex flex-col justify-between [&>*]:rounded-[0.5rem]">
-                <div className="h-[2.15rem] w-[23rem] bg-placeholder" />
-                <div className="h-[2rem] w-[10rem] bg-placeholder" />
-              </div>
-              <div className="h-[10.5rem] w-[7.5rem] rounded-[0.5rem] bg-placeholder" />
-            </div>
-          </li>
-        ))}
-      </ul>
-    );
-  }
+  const { data } = useMyGroupsQuery({ enabled: isAuthenticated });
 
   return (
     <ul className="flex flex-col gap-[1rem] pt-[2rem]">
@@ -89,3 +66,27 @@ const UserGroupContent = () => {
 };
 
 export default UserGroupPage;
+
+const PageSkeleton = () => (
+  <ul className="flex animate-pulse flex-col gap-[1rem] pt-[2rem]">
+    {Array.from({ length: 4 }).map((_, index) => (
+      <li
+        key={index}
+        className="border-placeholder px-[1.6rem] py-[0.9rem] shadow-bookgroup-card"
+      >
+        <div className="flex gap-[0.5rem] [&>*]:rounded-[0.5rem]">
+          <div className="h-[1.9rem] w-[4.34rem] bg-placeholder" />
+          <div className="h-[1.9rem] w-[4.34rem] bg-placeholder" />
+        </div>
+
+        <div className="flex justify-between gap-[1.5rem] pt-[1rem]">
+          <div className="flex flex-col justify-between [&>*]:rounded-[0.5rem]">
+            <div className="h-[2.15rem] w-[23rem] bg-placeholder" />
+            <div className="h-[2rem] w-[10rem] bg-placeholder" />
+          </div>
+          <div className="h-[10.5rem] w-[7.5rem] rounded-[0.5rem] bg-placeholder" />
+        </div>
+      </li>
+    ))}
+  </ul>
+);

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -97,7 +97,7 @@ const MyProfileForAuth = () => {
           </Menu.DropdownList>
         </Menu>
       </TopHeader>
-      <div className="flex flex-col gap-[2rem]">
+      <div className="flex flex-col gap-[1rem]">
         <ProfileInfo userId={USER_ID} />
         <Link href="/profile/me/edit" className="w-full">
           <Button colorScheme="main-light" size="full">
@@ -106,8 +106,10 @@ const MyProfileForAuth = () => {
             </span>
           </Button>
         </Link>
-        <ProfileBookShelf userId={USER_ID} />
-        <ProfileGroup userId={USER_ID} />
+        <div className="mt-[3rem] flex flex-col gap-[3rem]">
+          <ProfileBookShelf userId={USER_ID} />
+          <ProfileGroup userId={USER_ID} />
+        </div>
       </div>
     </>
   );

--- a/src/v1/profile/bookShelf/ProfileBookshelfPresenter.tsx
+++ b/src/v1/profile/bookShelf/ProfileBookshelfPresenter.tsx
@@ -12,7 +12,7 @@ const ProfileBookshelfPresenter = ({
   likeCount,
 }: APIBookshelf) => {
   return (
-    <div className="flex flex-col gap-[2rem]">
+    <div className="flex flex-col gap-[1rem]">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-bold">책장</h3>
         <div className="flex gap-[2rem]">

--- a/src/v1/profile/group/ProfileGroupContainer.tsx
+++ b/src/v1/profile/group/ProfileGroupContainer.tsx
@@ -1,4 +1,5 @@
 import useMyGroupsQuery from '@/queries/group/useMyGroupQuery';
+import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
 import { APIUser } from '@/types/user';
 import ProfileGroupPresenter from './ProfileGroupPresenter';
 
@@ -8,10 +9,17 @@ const ProfileGroupContainer = ({
   userId: 'me' | APIUser['userId'];
 }) => {
   const { isSuccess, data } = useMyGroupsQuery({ suspense: true });
+  const {
+    data: { userId: myId },
+  } = useMyProfileQuery({ enabled: userId === 'me' });
+
+  const isMeOwner = (ownerId: number) => ownerId === myId;
 
   if (!isSuccess) return null;
 
-  return <ProfileGroupPresenter userId={userId} {...data} />;
+  return (
+    <ProfileGroupPresenter userId={userId} isGroupOwner={isMeOwner} {...data} />
+  );
 };
 
 export default ProfileGroupContainer;

--- a/src/v1/profile/group/ProfileGroupPresenter.tsx
+++ b/src/v1/profile/group/ProfileGroupPresenter.tsx
@@ -7,11 +7,13 @@ import Link from 'next/link';
 interface ProfileGroupPresenterProps {
   userId: 'me' | APIUser['userId'];
   bookGroups: APIGroup[];
+  isGroupOwner?: (ownerId: number) => boolean;
 }
 
 const ProfileGroupPresenter = ({
   userId,
   bookGroups,
+  isGroupOwner,
 }: ProfileGroupPresenterProps) => {
   return (
     <div className="flex flex-col gap-[0.6rem]">
@@ -23,12 +25,12 @@ const ProfileGroupPresenter = ({
       </div>
 
       <ul className="flex gap-[1rem] overflow-scroll">
-        {bookGroups.map(({ bookGroupId, title, book: { imageUrl } }) => (
+        {bookGroups.map(({ bookGroupId, title, owner, book: { imageUrl } }) => (
           <li key={bookGroupId}>
             <SimpleBookGroupCard
               title={title}
               imageSource={imageUrl}
-              isOwner={false}
+              isOwner={!!isGroupOwner && isGroupOwner(owner.id)}
               bookGroupId={bookGroupId}
             />
           </li>

--- a/src/v1/profile/group/ProfileGroupPresenter.tsx
+++ b/src/v1/profile/group/ProfileGroupPresenter.tsx
@@ -16,7 +16,7 @@ const ProfileGroupPresenter = ({
   isGroupOwner,
 }: ProfileGroupPresenterProps) => {
   return (
-    <div className="flex flex-col gap-[0.6rem]">
+    <div className="mt-[0.5rem] flex flex-col gap-[1.5rem]">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-bold">참여한 모임</h3>
         <Link href={`/profile/${userId}/group`}>

--- a/src/v1/profile/group/ProfileGroupPresenter.tsx
+++ b/src/v1/profile/group/ProfileGroupPresenter.tsx
@@ -24,7 +24,7 @@ const ProfileGroupPresenter = ({
         </Link>
       </div>
 
-      <ul className="flex gap-[1rem] overflow-scroll">
+      <ul className="w-app flex gap-[1rem] overflow-y-hidden overflow-x-scroll px-[2rem]">
         {bookGroups.map(({ bookGroupId, title, owner, book: { imageUrl } }) => (
           <li key={bookGroupId}>
             <SimpleBookGroupCard


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- ProfileGroupPresenter 컴포넌트에 모임장 여부를 판단하기 위한 isGroupOwner prop을 추가했어요.
- 내가 참여한 모임 목록 페이지에 SSRSafeSuspense를 적용하여 hydrantion error를 해결했어요.
- 프로필 페이지 참여한 모임의 상하 스크롤을 제거하고, 화면 전체에서 좌우 수크롤이 생기도록 수정했어요.


# 관련 이슈

- Close #585  <!--이슈번호-->
