### PR TITLE
[#557] [도서 검색] 최근 검색어 api 요청

### DIFF
--- a/src/apis/book/index.ts
+++ b/src/apis/book/index.ts
@@ -101,6 +101,11 @@ const bookAPI = {
     publicApi.get<APIBestSellerRes>(
       `/aladin-api?QueryType=Bestseller&Cover=Big`
     ),
+
+  storeRecentSearch: (queryKeyword: string) =>
+    publicApi.get(
+      `/service-api/books?page=1&pageSize=1&query=${queryKeyword}&isStoreRecent=true`
+    ),
 };
 
 export default bookAPI;

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -9,6 +9,7 @@ import { APIBook } from '@/types/book';
 
 import useBookSearchQuery from '@/queries/book/useBookSearchQuery';
 import { useRecentSearchListQuery } from '@/queries/book/useRecentSearchesQuery';
+import bookAPI from '@/apis/book';
 
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
 import useDebounceValue from '@/hooks/useDebounce';
@@ -96,8 +97,13 @@ const BookSearchResult = ({ queryKeyword }: { queryKeyword: string }) => {
     ? bookSearchInfo.data.pages[0].totalCount
     : 0;
 
-  const handleBookClick = ({ bookId }: { bookId: APIBook['bookId'] }) => {
-    router.push(`/book/${bookId}`);
+  const handleBookClick = async ({ bookId }: { bookId: APIBook['bookId'] }) => {
+    try {
+      await bookAPI.storeRecentSearch(queryKeyword);
+      router.push(`/book/${bookId}`);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
# 구현 내용

도서 검색 이후 도서를 클릭하면
검색할 때 사용됐던 키워드가 최근 검색어로 저장됩니다

# 스크린샷
https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/048ae196-b3ba-445c-b129-4e7bbaacda89


# 관련 이슈

- Close #557 