### PR TITLE
[#591] 3D 책 컴포넌트, 책장 페이지 개선

### DIFF
--- a/src/app/bookshelf/[bookshelfId]/page.tsx
+++ b/src/app/bookshelf/[bookshelfId]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import Link from 'next/link';
 import { useInView } from 'react-intersection-observer';
 
-import type { APIBookshelf, APIBookshelfInfo } from '@/types/bookshelf';
+import type { APIBookshelf } from '@/types/bookshelf';
 
 import useBookShelfBooksQuery from '@/queries/bookshelf/useBookShelfBookListQuery';
 import useBookShelfInfoQuery from '@/queries/bookshelf/useBookShelfInfoQuery';
@@ -99,7 +99,6 @@ const BookShelfContent = ({
   bookshelfId,
 }: {
   bookshelfId: APIBookshelf['bookshelfId'];
-  userNickname?: APIBookshelfInfo['userNickname'];
 }) => {
   const isAuthenticated = checkAuthentication();
   const { ref, inView } = useInView();
@@ -121,28 +120,23 @@ const BookShelfContent = ({
   // TODO: Suspense 적용
   if (!isSuccess) return null;
 
-  return (
+  return isAuthenticated ? (
     <>
-      {isAuthenticated ? (
-        <>
-          {booksData.pages.map(page =>
-            page.books.map((rowBooks, idx) => (
-              <BookShelfRow key={idx} books={rowBooks} />
-            ))
-          )}
-          {!isFetchingNextPage && <div ref={ref} />}
-        </>
-      ) : (
-        <>
-          <BookShelfRow books={booksData.pages[0].books[0]} />
-          <DummyBookShelfRow />
-          <BookShelfLoginBox bookshelfId={bookshelfId} />
-        </>
+      {booksData.pages.map(page =>
+        page.books.map((rowBooks, idx) => (
+          <BookShelfRow key={idx} books={rowBooks} />
+        ))
       )}
+      {!isFetchingNextPage && <div ref={ref} />}
+    </>
+  ) : (
+    <>
+      <BookShelfRow books={booksData.pages[0].books[0]} />
+      <DummyBookShelfRow />
+      <BookShelfLoginBox bookshelfId={bookshelfId} />
     </>
   );
 };
-
 const DummyBookShelfRow = () => (
   <div className="pointer-events-none blur-sm">
     <BookShelfRow books={initialBookImageUrl} />

--- a/src/app/bookshelf/[bookshelfId]/page.tsx
+++ b/src/app/bookshelf/[bookshelfId]/page.tsx
@@ -1,23 +1,26 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useInView } from 'react-intersection-observer';
 import Link from 'next/link';
+import { useInView } from 'react-intersection-observer';
+
+import type { APIBookshelf, APIBookshelfInfo } from '@/types/bookshelf';
+
 import useBookShelfBooksQuery from '@/queries/bookshelf/useBookShelfBookListQuery';
 import useBookShelfInfoQuery from '@/queries/bookshelf/useBookShelfInfoQuery';
 import useMutateBookshelfLikeQuery from '@/queries/bookshelf/useMutateBookshelfLikeQuery';
-import useToast from '@/v1/base/Toast/useToast';
+import { useMyProfileId } from '@/queries/user/useMyProfileQuery';
 import { checkAuthentication } from '@/utils/helpers';
 import { IconKakao } from '@public/icons';
+import { KAKAO_LOGIN_URL } from '@/constants/url';
+
+import useToast from '@/v1/base/Toast/useToast';
 import TopNavigation from '@/v1/base/TopNavigation';
 import BookShelfRow from '@/v1/bookShelf/BookShelfRow';
 import Button from '@/v1/base/Button';
 import LikeButton from '@/v1/base/LikeButton';
 import BackButton from '@/v1/base/BackButton';
 import ShareButton from '@/v1/base/ShareButton';
-import type { APIBookshelf, APIBookshelfInfo } from '@/types/bookshelf';
-
-const KAKAO_OAUTH_LOGIN_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
 
 export default function UserBookShelfPage({
   params: { bookshelfId },
@@ -26,23 +29,6 @@ export default function UserBookShelfPage({
     bookshelfId: APIBookshelf['bookshelfId'];
   };
 }) {
-  const isAuthenticated = checkAuthentication();
-  const { data, isSuccess } = useBookShelfInfoQuery({ bookshelfId });
-  const { mutate: mutateBookshelfLike } =
-    useMutateBookshelfLikeQuery(bookshelfId);
-  const { show: showToast } = useToast();
-
-  if (!isSuccess) return null;
-
-  const handleClickLikeButton = () => {
-    if (!isAuthenticated) {
-      showToast({ message: '로그인 후 이용해주세요.', type: 'normal' });
-      return;
-    }
-
-    mutateBookshelfLike(data.isLiked);
-  };
-
   return (
     <div className="flex w-full flex-col">
       <TopNavigation>
@@ -53,37 +39,67 @@ export default function UserBookShelfPage({
           <ShareButton />
         </TopNavigation.RightItem>
       </TopNavigation>
-      <div className="mt-[0.8rem] flex flex-col gap-[0.8rem] pb-[2rem] pt-[1rem] font-bold">
-        <h1 className="font-subheading-bold">
-          <span className="text-main-900">{data.userNickname}</span>
-          님의 책장
-        </h1>
-        <div className="flex items-center justify-between">
-          <span className="text-black-600 font-body2-regular">
-            {`${data.job.jobGroupKoreanName} • ${data.job.jobNameKoreanName}`}
-          </span>
-          <LikeButton
-            isLiked={data.isLiked}
-            likeCount={data.likeCount}
-            onClick={handleClickLikeButton}
-          />
-        </div>
-      </div>
 
-      <BookShelfContent
-        bookshelfId={bookshelfId}
-        userNickname={data.userNickname}
-      />
+      <BookShelfInfo bookshelfId={bookshelfId} />
+      <BookShelfContent bookshelfId={bookshelfId} />
     </div>
   );
 }
 
+const BookShelfInfo = ({ bookshelfId }: { bookshelfId: number }) => {
+  const isAuthenticated = checkAuthentication();
+  const { show: showToast } = useToast();
+
+  const { data } = useBookShelfInfoQuery(bookshelfId);
+  const { isLiked, likeCount, userId, userNickname, job } = data;
+
+  const { mutate: mutateBookshelfLike } =
+    useMutateBookshelfLikeQuery(bookshelfId);
+
+  const { data: myId } = useMyProfileId({ enabled: isAuthenticated });
+
+  const handleClickLikeButton = () => {
+    if (!isAuthenticated) {
+      showToast({ message: '로그인 후 이용해주세요.', type: 'normal' });
+      return;
+    }
+
+    if (userId === myId) {
+      showToast({
+        message: '내 책장에는 좋아요를 누를 수 없어요.',
+        type: 'normal',
+      });
+      return;
+    }
+
+    mutateBookshelfLike(isLiked);
+  };
+
+  return (
+    <div className="mt-[0.8rem] flex flex-col gap-[0.8rem] pb-[2rem] pt-[1rem] font-bold">
+      <h1 className="font-subheading-bold">
+        <span className="text-main-900">{userNickname}</span>
+        님의 책장
+      </h1>
+      <div className="flex items-center justify-between">
+        <span className="text-black-600 font-body2-regular">
+          {`${job.jobGroupKoreanName} • ${job.jobNameKoreanName}`}
+        </span>
+        <LikeButton
+          isLiked={isLiked}
+          likeCount={likeCount}
+          onClick={handleClickLikeButton}
+        />
+      </div>
+    </div>
+  );
+};
+
 const BookShelfContent = ({
   bookshelfId,
-  userNickname,
 }: {
   bookshelfId: APIBookshelf['bookshelfId'];
-  userNickname: APIBookshelfInfo['userNickname'];
+  userNickname?: APIBookshelfInfo['userNickname'];
 }) => {
   const isAuthenticated = checkAuthentication();
   const { ref, inView } = useInView();
@@ -93,7 +109,6 @@ const BookShelfContent = ({
     fetchNextPage,
     hasNextPage,
     isSuccess,
-    isFetching,
     isFetchingNextPage,
   } = useBookShelfBooksQuery({ bookshelfId });
 
@@ -106,44 +121,64 @@ const BookShelfContent = ({
   // TODO: Suspense 적용
   if (!isSuccess) return null;
 
-  return isAuthenticated ? (
+  return (
     <>
-      {booksData.pages.map(page =>
-        page.books.map((rowBooks, idx) => (
-          <BookShelfRow key={idx} books={rowBooks} />
-        ))
+      {isAuthenticated ? (
+        <>
+          {booksData.pages.map(page =>
+            page.books.map((rowBooks, idx) => (
+              <BookShelfRow key={idx} books={rowBooks} />
+            ))
+          )}
+          {!isFetchingNextPage && <div ref={ref} />}
+        </>
+      ) : (
+        <>
+          <BookShelfRow books={booksData.pages[0].books[0]} />
+          <DummyBookShelfRow />
+          <BookShelfLoginBox bookshelfId={bookshelfId} />
+        </>
       )}
+    </>
+  );
+};
 
-      {isFetching && !isFetchingNextPage ? null : <div ref={ref} />}
-    </>
-  ) : (
-    <>
-      <BookShelfRow books={booksData.pages[0].books[0]} />
-      <div className="pointer-events-none blur-sm">
-        <BookShelfRow books={initialBookImageUrl} />
-      </div>
-      <div className="mt-[3.8rem] flex flex-col gap-[2rem] rounded-[4px] border border-[#CFCFCF] px-[1.7rem] py-[4rem]">
-        <p className="text-center font-body1-bold">
-          지금 로그인하면
-          <br />
-          책장에 담긴 모든 책을 볼 수 있어요!
-        </p>
-        <p className="text-center text-placeholder font-body2-regular">
-          <span className="text-main-900">{userNickname}</span>님의 책장에서
-          다양한
-          <br />
-          인사이트를 얻을 수 있어요.
-        </p>
-        <Link href={KAKAO_OAUTH_LOGIN_URL}>
-          <Button colorScheme="kakao" size="full">
-            <div className="flex items-center justify-center gap-[1rem]">
-              <IconKakao width={16} height={'auto'} />
-              <span className="font-body1-regular">카카오 로그인</span>
-            </div>
-          </Button>
-        </Link>
-      </div>
-    </>
+const DummyBookShelfRow = () => (
+  <div className="pointer-events-none blur-sm">
+    <BookShelfRow books={initialBookImageUrl} />
+  </div>
+);
+
+const BookShelfLoginBox = ({
+  bookshelfId,
+}: {
+  bookshelfId: APIBookshelf['bookshelfId'];
+}) => {
+  const { data } = useBookShelfInfoQuery(bookshelfId);
+  const { userNickname } = data;
+
+  return (
+    <div className="mt-[3.8rem] flex flex-col gap-[2rem] rounded-[4px] border border-[#CFCFCF] px-[1.7rem] py-[4rem]">
+      <p className="text-center font-body1-bold">
+        지금 로그인하면
+        <br />
+        책장에 담긴 모든 책을 볼 수 있어요!
+      </p>
+      <p className="text-center text-placeholder font-body2-regular">
+        <span className="text-main-900">{userNickname}</span>님의 책장에서
+        다양한
+        <br />
+        인사이트를 얻을 수 있어요.
+      </p>
+      <Link href={KAKAO_LOGIN_URL}>
+        <Button colorScheme="kakao" size="full">
+          <div className="flex items-center justify-center gap-[1rem]">
+            <IconKakao width={16} height={'auto'} />
+            <span className="font-body1-regular">카카오 로그인</span>
+          </div>
+        </Button>
+      </Link>
+    </div>
   );
 };
 

--- a/src/queries/bookshelf/useBookShelfInfoQuery.ts
+++ b/src/queries/bookshelf/useBookShelfInfoQuery.ts
@@ -1,15 +1,20 @@
-import bookshelfAPI from '@/apis/bookshelf';
+import { UseQueryOptions } from '@tanstack/react-query';
 import { APIBookshelfInfo } from '@/types/bookshelf';
-import { useQuery } from '@tanstack/react-query';
+import useQueryWithSuspense from '@/hooks/useQueryWithSuspense';
+import bookshelfAPI from '@/apis/bookshelf';
 import bookShelfKeys from './key';
 
-const useBookShelfInfoQuery = ({
-  bookshelfId,
-}: {
-  bookshelfId: APIBookshelfInfo['bookshelfId'];
-}) =>
-  useQuery(bookShelfKeys.info(bookshelfId), () =>
-    bookshelfAPI.getBookshelfInfo(bookshelfId).then(response => response.data)
+const useBookShelfInfoQuery = <TData = APIBookshelfInfo>(
+  bookshelfId: APIBookshelfInfo['bookshelfId'],
+  options?: UseQueryOptions<APIBookshelfInfo, unknown, TData>
+) =>
+  useQueryWithSuspense(
+    bookShelfKeys.info(bookshelfId),
+    () =>
+      bookshelfAPI
+        .getBookshelfInfo(bookshelfId)
+        .then(response => response.data),
+    options
   );
 
 export default useBookShelfInfoQuery;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -75,4 +75,9 @@
   .w-app {
     @apply relative -left-[2rem] w-[calc(100%+4rem)];
   }
+
+  .bg-blur {
+    box-shadow: inset 0 0 3rem #dddddd;
+    @apply bg-placeholder;
+  }
 }

--- a/src/v1/bookShelf/BookShelf.tsx
+++ b/src/v1/bookShelf/BookShelf.tsx
@@ -50,7 +50,7 @@ type BooksProps = Pick<APIBookshelf, 'books'>;
 
 const Books = ({ books }: BooksProps) => {
   return (
-    <ul className="grid grid-cols-4 px-[1rem]">
+    <ul className="grid grid-cols-4 px-[1.5rem]">
       {books.map(book => (
         <li key={book.bookId} className="flex justify-center">
           <Book {...book} />

--- a/src/v1/bookShelf/BookShelf.tsx
+++ b/src/v1/bookShelf/BookShelf.tsx
@@ -29,7 +29,7 @@ type InfoProps = Omit<APIBookshelf, 'books'>;
 
 const Info = ({ bookshelfName, bookshelfId, likeCount }: InfoProps) => {
   return (
-    <div className="flex flex-col gap-[1rem]">
+    <div className="flex flex-col gap-[1rem] px-[2rem]">
       <div className="flex items-center justify-between">
         <div className="font-body2-bold">{bookshelfName}</div>
         <Link href={`/bookshelf/${bookshelfId}`}>
@@ -50,7 +50,7 @@ type BooksProps = Pick<APIBookshelf, 'books'>;
 
 const Books = ({ books }: BooksProps) => {
   return (
-    <ul className="grid grid-cols-4 px-[0.5rem]">
+    <ul className="grid grid-cols-4 px-[1rem]">
       {books.map(book => (
         <li key={book.bookId} className="flex justify-center">
           <Book {...book} />

--- a/src/v1/bookShelf/BookShelf.tsx
+++ b/src/v1/bookShelf/BookShelf.tsx
@@ -1,11 +1,16 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+import ColorThief from 'colorthief';
+
+import { APIBook } from '@/types/book';
 import { APIBookshelf } from '@/types/bookshelf';
 import { IconArrowRight, IconHeart } from '@public/icons';
-import Link from 'next/link';
+
 import Badge from '@/v1/base/Badge';
-import Image from 'next/image';
-import { APIBook } from '@/types/book';
-import { ReactNode, useState } from 'react';
-import ColorThief from 'colorthief';
 
 const BookShelf = ({ children }: { children: ReactNode }) => {
   return <>{children}</>;
@@ -58,8 +63,10 @@ const Books = ({ books }: BooksProps) => {
 const Book = ({
   imageUrl,
   bookId,
+  title,
 }: Pick<APIBook, 'bookId' | 'title' | 'imageUrl'>) => {
   const [bookSpineColor, setBookSpineColor] = useState<string>();
+  const placeholderClassName = bookSpineColor ? '' : 'bg-blur';
 
   const handleOnLoadImage = (image: HTMLImageElement) => {
     const colorThief = new ColorThief();
@@ -71,44 +78,55 @@ const Book = ({
   };
 
   return (
-    <div
+    <Link
+      href={`/book/${bookId}`}
       className="relative flex"
       style={{
-        visibility: bookSpineColor ? 'visible' : 'hidden',
         transformStyle: 'preserve-3d',
         transform: 'perspective(140px)',
       }}
     >
+      {/** 책 옆면 (책등) */}
       <div
-        className="h-full w-[1.5rem]"
+        className={`h-full w-[1.5rem] ${placeholderClassName}`}
         style={{
           backgroundColor: bookSpineColor,
           transform: 'rotateY(320deg) translateX(1rem) translateZ(0.4rem)',
         }}
-      />
+      >
+        {/** 옆면과 표지 사이 여백을 메꾸기 위해 추가 */}
+        <div
+          className={`absolute -right-[0.5px] h-full w-[2px] ${placeholderClassName}`}
+          style={{ backgroundColor: bookSpineColor }}
+        />
+      </div>
+
+      {/** 책 하단 그림자 */}
       <div
         className="absolute bottom-0 h-2 w-[calc(100%-1.5rem)] shadow-[1px_4px_10px_4px_#b1b1b1]"
         style={{
           transform: 'rotateY(20deg) translateX(1.25rem) translateZ(-0.5rem)',
         }}
       />
-      <Link
-        className="relative"
-        href={`/book/${bookId}`}
+
+      {/** 책 표지 */}
+      <div
+        className="bg-blur relative h-[9.1rem] w-[6.5rem] rounded-[2px] after:absolute after:inset-0 after:border-[1px] after:border-black-900/[.06]"
         style={{
           transform: 'rotateY(22deg) translateZ(0.3rem)',
         }}
       >
         <Image
           src={imageUrl}
-          width={60}
-          height={90}
-          alt="book cover"
+          alt={title}
           onLoadingComplete={handleOnLoadImage}
-          quality={100}
+          className=" rounded-[1px] object-cover"
+          sizes="9.1rem"
+          fill
+          style={{ visibility: bookSpineColor ? 'visible' : 'hidden' }}
         />
-      </Link>
-    </div>
+      </div>
+    </Link>
   );
 };
 

--- a/src/v1/bookShelf/BookShelfCard.tsx
+++ b/src/v1/bookShelf/BookShelfCard.tsx
@@ -11,7 +11,7 @@ const BookShelfCard = ({
     <BookShelf>
       <div className="relative rounded-[2rem] pb-[2.5rem] pt-[2rem] shadow-[0px_0px_10px_0px_#D1D1D1]">
         <BookShelf.Background />
-        <div className="flex flex-col gap-[2.6rem] bg-white px-[2rem]">
+        <div className="flex flex-col gap-[2.6rem] bg-white">
           <BookShelf.Info
             bookshelfName={bookshelfName}
             bookshelfId={bookshelfId}

--- a/src/v1/bookShelf/BookShelfRow.tsx
+++ b/src/v1/bookShelf/BookShelfRow.tsx
@@ -4,7 +4,7 @@ import BookShelf from './BookShelf';
 const BookShelfRow = ({ books }: Pick<APIBookshelf, 'books'>) => {
   return (
     <BookShelf>
-      <div className="relative left-[-2rem] w-[calc(100%+4rem)] px-[-2rem] pb-[2.5rem] pt-[2rem] shadow-[0px_28px_20px_-16px_#D1D1D1]">
+      <div className="relative left-[-2rem] w-[calc(100%+4rem)] pb-[2.5rem] pt-[2rem] shadow-[0px_28px_20px_-16px_#D1D1D1]">
         <BookShelf.Background />
         <BookShelf.Books books={books} />
       </div>


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- 3D 책 컴포넌트가 완전히 로딩되기 전에 placeholder가 보여지도록 수정했어요.
- 책장 페이지를 서버 컴포넌트로 만들었어요.
- 책장 관련 컴포넌트의 스타일을 수정했어요.
  - padding을 줄여 3D 책이 보이는 영역을 넓혔어요.
- 내 책장에는 좋아요를 누를 수 없도록 수정했어요.

<!-- - ex) 결제 기능 구현 -->

# 스크린샷
<img src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/3794afda-409f-406b-8ba7-040913bae403" width="300" />


<!-- 없는 경우 생략한다. -->


# 관련 이슈

- Close #591 <!--이슈번호-->
