### PR TITLE
[#602] [모임 생성] 퍼널 progress bar, stepper 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,7 +43,7 @@ const nextConfig = {
       },
       {
         protocol: 'http',
-        hostname: 'k.kakaocdn.net',
+        hostname: '*.kakaocdn.net',
         port: '',
         pathname: '/**',
       },

--- a/public/icons/check-stroke.svg
+++ b/public/icons/check-stroke.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5L4 8L11 1" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/check.svg
+++ b/public/icons/check.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="#FFA436" xmlns="http://www.w3.org/2000/svg">
 <path d="M9.99974 15.1715L19.1917 5.97852L20.6067 7.39252L9.99974 17.9995L3.63574 11.6355L5.04974 10.2215L9.99974 15.1715Z" fill="#FFA436"/>
 </svg>

--- a/public/icons/index.ts
+++ b/public/icons/index.ts
@@ -30,6 +30,7 @@ export { default as IconErrorExclamation } from './error-with-exclamation.svg';
 export { default as IconAvatar } from './avatar.svg';
 export { default as IconCalendar } from './calendar.svg';
 export { default as IconCheck } from './check.svg';
+export { default as IconCheckStroke } from './check-stroke.svg';
 export { default as IconComments } from './comments.svg';
 export { default as IconDelete } from './delete.svg';
 export { default as IconMembers } from './members.svg';

--- a/src/hocs/withScrollLockOnFocus.tsx
+++ b/src/hocs/withScrollLockOnFocus.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, Ref, useState } from 'react';
+
+import useRemoveVerticalScroll from '@/hooks/useRemoveVerticalScroll';
+
+const withScrollLockOnFocus = <P extends object>(
+  WrappedComponent: React.ComponentType<P>
+) => {
+  const Component = (props: P, ref: Ref<HTMLElement>) => {
+    const [focus, setFocus] = useState(false);
+    useRemoveVerticalScroll({ enabled: focus });
+
+    return (
+      <WrappedComponent
+        {...props}
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
+        ref={ref}
+      />
+    );
+  };
+
+  return forwardRef(Component);
+};
+
+export default withScrollLockOnFocus;

--- a/src/hooks/useRemoveVerticalScroll.ts
+++ b/src/hooks/useRemoveVerticalScroll.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { nonPassive } from '@/utils/eventListener';
 
 type Options = {
-  enabled?: boolean;
+  enabled: boolean;
 };
 
 const getTouchXY = (event: TouchEvent | WheelEvent) =>
@@ -11,7 +11,7 @@ const getTouchXY = (event: TouchEvent | WheelEvent) =>
     : [0, 0];
 
 const useRemoveVerticalScroll = (options?: Options) => {
-  const enabled = options?.enabled;
+  const enabled = options ? options.enabled : true;
 
   const touchStartRef = useRef([0, 0]);
 

--- a/src/stories/base/ProgressBar.stories.tsx
+++ b/src/stories/base/ProgressBar.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ProgressBar from '@/v1/base/ProgressBar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Base/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Default: Story = {
+  args: { value: 30 },
+};

--- a/src/stories/base/Stepper.stories.tsx
+++ b/src/stories/base/Stepper.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Stepper from '@/v1/base/Stepper';
+
+const meta: Meta<typeof Stepper> = {
+  title: 'Base/Stepper',
+  component: Stepper,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Stepper>;
+
+export const Default: Story = {
+  args: { activeIndex: 0 },
+
+  render: args => (
+    <Stepper {...args}>
+      <Stepper.Step />
+      <Stepper.Step />
+      <Stepper.Step />
+    </Stepper>
+  ),
+};

--- a/src/v1/base/ProgressBar.tsx
+++ b/src/v1/base/ProgressBar.tsx
@@ -1,0 +1,29 @@
+/**
+ * @param value percentage
+ */
+const ProgressBar = ({
+  value,
+  className,
+}: {
+  value: number;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={
+        'absolute inset-x-0 h-[0.2rem] w-full overflow-hidden ' + className
+      }
+    >
+      <div className="absolute h-full w-full bg-main-500" />
+      <div
+        className="absolute h-full w-full bg-main-900"
+        style={{
+          transform: `translateX(-${100 - value}%)`,
+          transition: 'transform 0.4s 0.1s ease-in-out',
+        }}
+      />
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/v1/base/ProgressBar.tsx
+++ b/src/v1/base/ProgressBar.tsx
@@ -19,7 +19,7 @@ const ProgressBar = ({
         className="absolute h-full w-full bg-main-900"
         style={{
           transform: `translateX(-${100 - value}%)`,
-          transition: 'transform 0.4s 0.1s ease-in-out',
+          transition: 'transform 0.4s ease-in-out',
         }}
       />
     </div>

--- a/src/v1/base/Stepper.tsx
+++ b/src/v1/base/Stepper.tsx
@@ -73,6 +73,8 @@ const Step = ({
 }) => {
   const { status, index } = useContext(StepperContext);
   const statusClasses = getStepClasses(status);
+  const activeAnimationClasses =
+    index !== 0 ? 'opacity-0 animate-stepper-transition' : 'opacity-1';
 
   const stepNumberToRender = index + 1;
   const labelToRender = label ? label : stepNumberToRender;
@@ -84,7 +86,9 @@ const Step = ({
       {status === 'complete' ? (
         <IconCheckStroke className="h-auto w-[1rem]" />
       ) : status === 'active' ? (
-        <p className=" relative animate-stepper-transition self-baseline whitespace-nowrap px-[1.2rem] py-[0.4rem] text-white opacity-0 font-body2-bold">
+        <p
+          className={`relative self-baseline whitespace-nowrap px-[1.2rem] py-[0.4rem] text-white font-body2-bold ${activeAnimationClasses}`}
+        >
           {labelToRender}
         </p>
       ) : (

--- a/src/v1/base/Stepper.tsx
+++ b/src/v1/base/Stepper.tsx
@@ -52,12 +52,13 @@ const Stepper = ({
   );
 };
 
-const getStepClasses = (status: StepStatus) => {
+const getStepClasses = (status: StepStatus, label?: string) => {
   switch (status) {
     case 'complete':
       return 'bg-main-900';
+    // TODO: label text width 계산 로직 추가
     case 'active':
-      return 'bg-main-900 w-[7.4rem] delay-[400]';
+      return `bg-main-900 ${label ? 'w-[7.4rem]' : ''}`;
     case 'incomplete':
     default:
       return 'bg-main-500';
@@ -72,9 +73,15 @@ const Step = ({
   children?: ReactNode;
 }) => {
   const { status, index } = useContext(StepperContext);
-  const statusClasses = getStepClasses(status);
+
+  const statusClasses = getStepClasses(status, label);
+  const labelPositionClass = label
+    ? 'self-baseline px-[1.2rem]'
+    : 'self-center';
+
+  // 첫번째 스텝이 아니고, 라벨 text가 있는 경우만 opacity transition 적용
   const activeAnimationClasses =
-    index !== 0 ? 'opacity-0 animate-stepper-transition' : 'opacity-1';
+    index !== 0 && label ? 'opacity-0 animate-stepper-transition' : 'opacity-1';
 
   const stepNumberToRender = index + 1;
   const labelToRender = label ? label : stepNumberToRender;
@@ -87,12 +94,12 @@ const Step = ({
         <IconCheckStroke className="h-auto w-[1rem]" />
       ) : status === 'active' ? (
         <p
-          className={`relative self-baseline whitespace-nowrap px-[1.2rem] py-[0.4rem] text-white font-body2-bold ${activeAnimationClasses}`}
+          className={`relative whitespace-nowrap text-white font-body2-bold ${activeAnimationClasses} ${labelPositionClass}`}
         >
           {labelToRender}
         </p>
       ) : (
-        <p className="relaive text-white font-body2-bold">
+        <p className="relative text-white font-body2-bold">
           {stepNumberToRender}
         </p>
       )}

--- a/src/v1/base/Stepper.tsx
+++ b/src/v1/base/Stepper.tsx
@@ -57,25 +57,40 @@ const getStepClasses = (status: StepStatus) => {
     case 'complete':
       return 'bg-main-900';
     case 'active':
-      return 'bg-main-900 scale-[1.3] delay-500';
+      return 'bg-main-900 w-[7.4rem] delay-[400]';
     case 'incomplete':
     default:
       return 'bg-main-500';
   }
 };
 
-const Step = ({ children }: { children?: ReactNode }) => {
+const Step = ({
+  label,
+  children,
+}: {
+  label?: string;
+  children?: ReactNode;
+}) => {
   const { status, index } = useContext(StepperContext);
   const statusClasses = getStepClasses(status);
 
+  const stepNumberToRender = index + 1;
+  const labelToRender = label ? label : stepNumberToRender;
+
   return (
     <div
-      className={`relative flex h-[1.8rem] w-[1.8rem] shrink-0 flex-col items-center justify-center rounded-full duration-500 ${statusClasses}`}
+      className={`relative flex h-[3rem] w-[3rem] shrink-0 flex-col items-center justify-center rounded-full duration-500 ${statusClasses} overflow-hidden`}
     >
       {status === 'complete' ? (
         <IconCheckStroke className="h-auto w-[1rem]" />
+      ) : status === 'active' ? (
+        <p className=" relative animate-stepper-transition self-baseline whitespace-nowrap px-[1.2rem] py-[0.4rem] text-white opacity-0 font-body2-bold">
+          {labelToRender}
+        </p>
       ) : (
-        <p className="absolute text-white font-caption2-bold">{index + 1}</p>
+        <p className="relaive text-white font-body2-bold">
+          {stepNumberToRender}
+        </p>
       )}
       {children}
     </div>

--- a/src/v1/base/Stepper.tsx
+++ b/src/v1/base/Stepper.tsx
@@ -1,0 +1,87 @@
+import {
+  Children,
+  createContext,
+  PropsWithChildren,
+  ReactNode,
+  useContext,
+} from 'react';
+
+import { IconCheckStroke } from '@public/icons';
+import ProgressBar from '@/v1/base/ProgressBar';
+
+type StepStatus = 'complete' | 'incomplete' | 'active';
+
+type StepContextValues = {
+  index: number;
+  status: StepStatus;
+  count: number;
+};
+
+const StepperContext = createContext<StepContextValues>(
+  {} as StepContextValues
+);
+
+const Stepper = ({
+  activeIndex,
+  children,
+}: PropsWithChildren<{ activeIndex: number }>) => {
+  const stepElements = Children.toArray(children);
+  const stepCount = stepElements.length;
+
+  const progressPercent =
+    activeIndex === 0 ? 0 : Math.ceil((activeIndex / (stepCount - 1)) * 100);
+
+  const getStepStatus = (step: number): StepStatus => {
+    if (step < activeIndex) return 'complete';
+    if (step > activeIndex) return 'incomplete';
+    return 'active';
+  };
+
+  return (
+    <div className="relative z-[1] flex w-full items-center justify-between">
+      <ProgressBar value={progressPercent} className="-z-[1]" />
+      {stepElements.map((child, index) => (
+        <StepperContext.Provider
+          key={index}
+          value={{ index, status: getStepStatus(index), count: stepCount }}
+        >
+          {child}
+        </StepperContext.Provider>
+      ))}
+    </div>
+  );
+};
+
+const getStepClasses = (status: StepStatus) => {
+  switch (status) {
+    case 'complete':
+      return 'bg-main-900';
+    case 'active':
+      return 'bg-main-900 scale-[1.3] delay-500';
+    case 'incomplete':
+    default:
+      return 'bg-main-500';
+  }
+};
+
+const Step = ({ children }: { children?: ReactNode }) => {
+  const { status, index } = useContext(StepperContext);
+  const statusClasses = getStepClasses(status);
+
+  return (
+    <div
+      className={`relative flex h-[1.8rem] w-[1.8rem] shrink-0 flex-col items-center justify-center rounded-full duration-500 ${statusClasses}`}
+    >
+      {status === 'complete' ? (
+        <IconCheckStroke className="h-auto w-[1rem]" />
+      ) : (
+        <p className="absolute text-white font-caption2-bold">{index + 1}</p>
+      )}
+      {children}
+    </div>
+  );
+};
+
+Stepper.Step = Step;
+
+export default Stepper;

--- a/src/v1/bookGroup/create/CreateBookGroupFunnel.tsx
+++ b/src/v1/bookGroup/create/CreateBookGroupFunnel.tsx
@@ -14,6 +14,7 @@ import { SERVICE_ERROR_MESSAGE } from '@/constants';
 
 import { IconArrowLeft } from '@public/icons';
 import TopNavigation from '@/v1/base/TopNavigation';
+import Stepper from '@/v1/base/Stepper';
 import {
   EnterTitleStep,
   SelectBookStep,
@@ -33,6 +34,9 @@ const CreateBookGroupFunnel = () => {
   const [Funnel, setStep, currentStep] = useFunnel(FUNNEL_STEPS, {
     initialStep: 'SelectBook',
   });
+  const stepIndex = FUNNEL_STEPS.indexOf(currentStep);
+  const activeStep = stepIndex !== -1 ? stepIndex : 0;
+
   const { show: showToast } = useToast();
   const { mutate } = useCreateBookGroupMutation();
 
@@ -110,6 +114,16 @@ const CreateBookGroupFunnel = () => {
           <IconArrowLeft onClick={handleBackButtonClick} />
         </TopNavigation.LeftItem>
       </TopNavigation>
+
+      <div className="sticky top-[5.4rem] z-10 -ml-[2rem] w-[calc(100%+4rem)] bg-white px-[2rem] pb-[3rem] pt-[1rem]">
+        <div className="relative left-1/2 w-[20rem] -translate-x-1/2 ">
+          <Stepper activeIndex={activeStep}>
+            {FUNNEL_STEPS.map((_, idx) => {
+              return <Stepper.Step key={idx} />;
+            })}
+          </Stepper>
+        </div>
+      </div>
 
       <form>
         <Funnel>

--- a/src/v1/bookGroup/create/CreateBookGroupFunnel.tsx
+++ b/src/v1/bookGroup/create/CreateBookGroupFunnel.tsx
@@ -29,6 +29,13 @@ const FUNNEL_STEPS = [
   'SelectJoinType',
 ] as const;
 
+const steps = [
+  { label: '도서선택' },
+  { label: '모임이름' },
+  { label: '모임정보' },
+  { label: '가입유형' },
+];
+
 const CreateBookGroupFunnel = () => {
   const router = useRouter();
   const [Funnel, setStep, currentStep] = useFunnel(FUNNEL_STEPS, {
@@ -116,10 +123,10 @@ const CreateBookGroupFunnel = () => {
       </TopNavigation>
 
       <div className="sticky top-[5.4rem] z-10 -ml-[2rem] w-[calc(100%+4rem)] bg-white px-[2rem] pb-[3rem] pt-[1rem]">
-        <div className="relative left-1/2 w-[20rem] -translate-x-1/2 ">
+        <div className="relative left-1/2 w-[98%] -translate-x-1/2 ">
           <Stepper activeIndex={activeStep}>
-            {FUNNEL_STEPS.map((_, idx) => {
-              return <Stepper.Step key={idx} />;
+            {steps.map(({ label }, idx) => {
+              return <Stepper.Step key={idx} label={label} />;
             })}
           </Stepper>
         </div>

--- a/src/v1/bookGroup/create/steps/EnterTitleStep/EnterTitleStep.tsx
+++ b/src/v1/bookGroup/create/steps/EnterTitleStep/EnterTitleStep.tsx
@@ -3,11 +3,15 @@ import { useFormContext } from 'react-hook-form';
 import type { MoveFunnelStepProps } from '@/v1/base/Funnel';
 import type { EnterTitleStepFormValues } from '../../types';
 
+import useRemoveVerticalScroll from '@/hooks/useRemoveVerticalScroll';
+
 import BottomActionButton from '@/v1/base/BottomActionButton';
 import { TitleField } from './fields';
 
 const EnterTitleStep = ({ onNextStep }: MoveFunnelStepProps) => {
   const { handleSubmit } = useFormContext<EnterTitleStepFormValues>();
+
+  useRemoveVerticalScroll();
 
   return (
     <article>

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/fields/JoinPasswordFieldset.tsx
@@ -10,6 +10,7 @@ import type {
 import ErrorMessage from '@/v1/base/ErrorMessage';
 import Input from '@/v1/base/Input';
 import InputLength from '@/v1/base/InputLength';
+import withScrollLockOnFocus from '@/hocs/withScrollLockOnFocus';
 
 type JoinPasswordFieldsetProps = {
   joinTypeFieldName: JoinTypeStepFieldName;
@@ -33,6 +34,8 @@ const JoinPasswordFieldset = ({
   );
 };
 
+const ScrollLockInput = withScrollLockOnFocus(Input);
+
 const JoinQuestionField = ({ name }: JoinTypeStepFieldProp) => {
   const {
     register,
@@ -48,7 +51,7 @@ const JoinQuestionField = ({ name }: JoinTypeStepFieldProp) => {
   return (
     <label className="flex flex-col gap-[0.5rem]">
       <p>가입 문제</p>
-      <Input
+      <ScrollLockInput
         placeholder="모임에 가입하기 위한 적절한 문제를 작성해주세요"
         {...register(name, {
           required: '1 ~ 30글자의 가입 문제가 필요해요',
@@ -86,7 +89,7 @@ const JoinAnswerField = ({ name }: JoinTypeStepFieldProp) => {
   return (
     <label className="flex flex-col gap-[0.5rem]">
       <p>정답</p>
-      <Input
+      <ScrollLockInput
         placeholder="띄어쓰기 없이 정답을 작성해주세요"
         {...register(name, {
           required: '띄어쓰기 없이 10글자 이하의 정답이 필요해요',

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -34,6 +34,7 @@ const SetUpDetailStep = ({
 
   return (
     <article className="flex flex-col gap-[2.5rem] overflow-y-scroll pb-[7rem]">
+      <h2 className="font-subheading-bold">모임 정보를 설정해주세요</h2>
       <TitleField name={'title'} />
       <SelectedBookInfoField
         bookId={getValues('book.bookId')}

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -6,6 +6,7 @@ import type { SetUpDetailStepFormValues } from '../../types';
 import { MAX_MEMBER_COUNT_OPTIONS } from '@/constants';
 import { getTodayDate } from '@/utils/date';
 
+import withScrollLockOnFocus from '@/hocs/withScrollLockOnFocus';
 import BottomActionButton from '@/v1/base/BottomActionButton';
 import DatePicker from '@/v1/base/DatePicker';
 import ErrorMessage from '@/v1/base/ErrorMessage';
@@ -68,6 +69,8 @@ type SetUpDetailFieldProps = {
   name: keyof SetUpDetailStepFormValues;
 };
 
+const ScrollLockInput = withScrollLockOnFocus(Input);
+
 const TitleField = ({ name }: SetUpDetailFieldProps) => {
   const {
     register,
@@ -82,7 +85,7 @@ const TitleField = ({ name }: SetUpDetailFieldProps) => {
 
   return (
     <section className="flex flex-col gap-[0.5rem]">
-      <Input
+      <ScrollLockInput
         fontSize="large"
         inputStyle="line"
         error={!!titleErrors}
@@ -131,6 +134,8 @@ const SelectedBookInfoField = ({
   );
 };
 
+const ScrollLockTextArea = withScrollLockOnFocus(TextArea);
+
 const IntroduceField = ({ name }: SetUpDetailFieldProps) => {
   const {
     register,
@@ -142,7 +147,7 @@ const IntroduceField = ({ name }: SetUpDetailFieldProps) => {
   return (
     <section className="flex flex-col gap-[1.2rem]">
       <h2>활동 내용</h2>
-      <TextArea
+      <ScrollLockTextArea
         count={true}
         error={!!introduceErrors}
         placeholder="독서모임에서 어떤 활동을 할 계획인지 자세히 설명해주세요"
@@ -153,7 +158,7 @@ const IntroduceField = ({ name }: SetUpDetailFieldProps) => {
         })}
       >
         <ErrorMessage>{introduceErrors?.message}</ErrorMessage>
-      </TextArea>
+      </ScrollLockTextArea>
     </section>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,7 +88,7 @@ module.exports = {
         'bookgroup-card': '0 0 6px rgba(180,180,180,0.25)',
       },
       keyframes: {
-        'page-transition': {
+        'opacity-show': {
           from: { opacity: 0 },
           to: { opacity: 1 },
         },
@@ -116,13 +116,14 @@ module.exports = {
         },
       },
       animation: {
-        'page-transition': 'page-transition 0.2s forwards ease-in-out',
+        'page-transition': 'opacity-show 0.2s forwards ease-in-out',
         'slide-in': '0.3s forwards slide-in ease-in-out',
         'slide-out': '0.3s forwards slide-out ease-in-out',
         'slide-init': '0.3s forwards slide-init ease-in-out',
         'dot-flash': '2s infinite dot-flash linear',
         'dot-flash-delay-0.5': '2s 0.5s infinite dot-flash linear',
         'dot-flash-delay-1': '2s 1s infinite dot-flash linear',
+        'stepper-transition': 'opacity-show 0.2s 0.2s forwards',
       },
       content: {
         search: 'url("/icons/search.svg")',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -123,7 +123,7 @@ module.exports = {
         'dot-flash': '2s infinite dot-flash linear',
         'dot-flash-delay-0.5': '2s 0.5s infinite dot-flash linear',
         'dot-flash-delay-1': '2s 1s infinite dot-flash linear',
-        'stepper-transition': 'opacity-show 0.2s 0.2s forwards',
+        'stepper-transition': 'opacity-show 0.2s 0.1s forwards',
       },
       content: {
         search: 'url("/icons/search.svg")',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,8 +31,9 @@ module.exports = {
       },
       colors: {
         main: {
-          400: '#F5F4EE',
-          500: '#FAF0DD',
+          300: '#F5F4EE',
+          400: '#FAF0DD',
+          500: '#FFDEB6',
           600: '#FFD480', // use with opacity 18%
           700: '#FFC073',
           800: '#F6AD55',


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

### ProgressBar 컴포넌트
- percentage 값을 `value` prop으로 받아 현재 진행정도를 표현하는 ProgressBar 컴포넌트를 구현했어요.
- 스토리북에서 확인할 수 있어요.

### Stepper 컴포넌트
- 퍼널 페이지에서 현재 스텝을 표시하기 위한 Stepper 컴포넌트를 구현했어요.
- 스토리북에서 확인할 수 있어요.

### `withScrollLockOnFocus` HOC 구현
- input, textarea 요소에서 타이핑을 위해 focus하는 경우, 상하 scroll이 제거되는 HOC를 구현했어요.

### 모임 생성 퍼널
- 퍼널 페이지에 `Stepper`를 적용했어요.
- 각 스텝의 input, textarea 요소에 `withScrollLockOnFocus` HOC를 적용했어요.

<!-- - ex) 결제 기능 구현 -->


# 스크린샷

https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/4f2fe733-e12c-4e9c-a4e1-adc623f80369


# 관련 이슈

- Close #602 <!--이슈번호-->
