### PR TITLE
[#608] 페이지 접근 권한 부여

### DIFF
--- a/src/app/group/[groupId]/edit/page.tsx
+++ b/src/app/group/[groupId]/edit/page.tsx
@@ -10,11 +10,9 @@ import {
 import type { APIGroupDetail, APIEditBookGroup } from '@/types/group';
 
 import { SERVICE_ERROR_MESSAGE } from '@/constants';
-import {
-  checkAuthentication,
-  isAxiosErrorWithCustomCode,
-} from '@/utils/helpers';
+import { isAxiosErrorWithCustomCode } from '@/utils/helpers';
 
+import withAuthRequired from '@/hocs/withAuthRequired';
 import useToast from '@/v1/base/Toast/useToast';
 import BookGroupEditDateForm from '@/v1/bookGroup/edit/BookGroupEditDateForm';
 import BookGroupEditIntroduceForm from '@/v1/bookGroup/edit/BookGroupEditIntroduceForm';
@@ -28,13 +26,15 @@ const BookGroupEditPage = ({
 }) => {
   const router = useRouter();
 
-  const isAuthenticated = checkAuthentication();
-
   const { data: bookGroupData } = useBookGroupEditCurrentInfo(groupId);
   const { isOwner, title, description, maxMemberCount, startDate, endDate } =
     bookGroupData;
 
-  if (!isAuthenticated || !isOwner) {
+  /**
+   * @todo
+   * 401 페이지 만들기 (접근 권한이 없어요)
+   */
+  if (!isOwner) {
     notFound();
   }
 
@@ -99,4 +99,6 @@ const BookGroupEditPage = ({
   );
 };
 
-export default BookGroupEditPage;
+const AuthRequiredBookGroupEditPage = withAuthRequired(BookGroupEditPage);
+
+export default AuthRequiredBookGroupEditPage;

--- a/src/app/group/[groupId]/edit/page.tsx
+++ b/src/app/group/[groupId]/edit/page.tsx
@@ -11,9 +11,9 @@ import type { APIGroupDetail, APIEditBookGroup } from '@/types/group';
 
 import { SERVICE_ERROR_MESSAGE } from '@/constants';
 import { isAxiosErrorWithCustomCode } from '@/utils/helpers';
+import useToast from '@/v1/base/Toast/useToast';
 
 import withAuthRequired from '@/hocs/withAuthRequired';
-import useToast from '@/v1/base/Toast/useToast';
 import BookGroupEditDateForm from '@/v1/bookGroup/edit/BookGroupEditDateForm';
 import BookGroupEditIntroduceForm from '@/v1/bookGroup/edit/BookGroupEditIntroduceForm';
 import BookGroupEditTitleForm from '@/v1/bookGroup/edit/BookGroupEditTitleForm';
@@ -99,6 +99,4 @@ const BookGroupEditPage = ({
   );
 };
 
-const AuthRequiredBookGroupEditPage = withAuthRequired(BookGroupEditPage);
-
-export default AuthRequiredBookGroupEditPage;
+export default withAuthRequired(BookGroupEditPage);

--- a/src/app/group/[groupId]/join/page.tsx
+++ b/src/app/group/[groupId]/join/page.tsx
@@ -6,6 +6,8 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import useJoinBookGroup from '@/hooks/group/useJoinBookGroup';
 
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+import withAuthRequired from '@/hocs/withAuthRequired';
+
 import Loading from '@/v1/base/Loading';
 import Input from '@/v1/base/Input';
 import InputLength from '@/v1/base/InputLength';
@@ -35,6 +37,10 @@ const JoinBookGroupPage = ({
     </SSRSafeSuspense>
   );
 };
+
+const AuthRequiredJoinBookGroupPage = withAuthRequired(JoinBookGroupPage);
+
+export default AuthRequiredJoinBookGroupPage;
 
 const BookGroupJoinForm = ({ groupId }: { groupId: number }) => {
   const router = useRouter();
@@ -100,5 +106,3 @@ const BookGroupJoinForm = ({ groupId }: { groupId: number }) => {
     </form>
   );
 };
-
-export default JoinBookGroupPage;

--- a/src/app/group/[groupId]/join/page.tsx
+++ b/src/app/group/[groupId]/join/page.tsx
@@ -38,9 +38,7 @@ const JoinBookGroupPage = ({
   );
 };
 
-const AuthRequiredJoinBookGroupPage = withAuthRequired(JoinBookGroupPage);
-
-export default AuthRequiredJoinBookGroupPage;
+export default withAuthRequired(JoinBookGroupPage);
 
 const BookGroupJoinForm = ({ groupId }: { groupId: number }) => {
   const router = useRouter();

--- a/src/app/group/create/page.tsx
+++ b/src/app/group/create/page.tsx
@@ -5,11 +5,7 @@ import withAuthRequired from '@/hocs/withAuthRequired';
 import CreateBookGroupFunnel from '@/v1/bookGroup/create/CreateBookGroupFunnel';
 
 const GroupCreateFunnelPage = () => {
-  const AuthRequiredCreateBookGroupFunnel = withAuthRequired(
-    CreateBookGroupFunnel
-  );
-
-  return <AuthRequiredCreateBookGroupFunnel />;
+  return <CreateBookGroupFunnel />;
 };
 
-export default GroupCreateFunnelPage;
+export default withAuthRequired(GroupCreateFunnelPage);

--- a/src/app/group/create/page.tsx
+++ b/src/app/group/create/page.tsx
@@ -1,7 +1,15 @@
+'use client';
+
+import withAuthRequired from '@/hocs/withAuthRequired';
+
 import CreateBookGroupFunnel from '@/v1/bookGroup/create/CreateBookGroupFunnel';
 
 const GroupCreateFunnelPage = () => {
-  return <CreateBookGroupFunnel />;
+  const AuthRequiredCreateBookGroupFunnel = withAuthRequired(
+    CreateBookGroupFunnel
+  );
+
+  return <AuthRequiredCreateBookGroupFunnel />;
 };
 
 export default GroupCreateFunnelPage;

--- a/src/app/profile/me/add/page.tsx
+++ b/src/app/profile/me/add/page.tsx
@@ -10,14 +10,14 @@ import withAuthRequired from '@/hocs/withAuthRequired';
 import AddJobProfile from '@/v1/profile/AddJobProfile';
 
 const AddJobProfilePage = () => {
-  const AuthRequiredContents = withAuthRequired(Contents);
-
   return (
     <SSRSafeSuspense fallback={null}>
-      <AuthRequiredContents />
+      <Contents />
     </SSRSafeSuspense>
   );
 };
+
+export default withAuthRequired(AddJobProfilePage);
 
 const Contents = () => {
   const isAuthenticated = checkAuthentication();
@@ -27,5 +27,3 @@ const Contents = () => {
     <AddJobProfile jobCategories={allJobQuery.data.jobGroups} />
   ) : null;
 };
-
-export default AddJobProfilePage;

--- a/src/app/profile/me/add/page.tsx
+++ b/src/app/profile/me/add/page.tsx
@@ -4,13 +4,17 @@ import useAllJobQuery from '@/queries/job/useAllJobQuery';
 
 import { checkAuthentication } from '@/utils/helpers';
 
-import AddJobProfile from '@/v1/profile/AddJobProfile';
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+import withAuthRequired from '@/hocs/withAuthRequired';
+
+import AddJobProfile from '@/v1/profile/AddJobProfile';
 
 const AddJobProfilePage = () => {
+  const AuthRequiredContents = withAuthRequired(Contents);
+
   return (
     <SSRSafeSuspense fallback={null}>
-      <Contents />
+      <AuthRequiredContents />
     </SSRSafeSuspense>
   );
 };

--- a/src/app/profile/me/edit/page.tsx
+++ b/src/app/profile/me/edit/page.tsx
@@ -12,14 +12,14 @@ import EditProfile from '@/v1/profile/EditProfile';
 import Loading from '@/v1/base/Loading';
 
 const EditProfilePage = () => {
-  const AuthRequiredContents = withAuthRequired(Contents);
-
   return (
     <SSRSafeSuspense fallback={<Loading fullpage />}>
-      <AuthRequiredContents />
+      <Contents />
     </SSRSafeSuspense>
   );
 };
+
+export default withAuthRequired(EditProfilePage);
 
 const Contents = () => {
   const isAuthenticated = checkAuthentication();
@@ -30,5 +30,3 @@ const Contents = () => {
     <EditProfile profile={profileData} jobGroups={allJobQuery.data.jobGroups} />
   ) : null;
 };
-
-export default EditProfilePage;

--- a/src/app/profile/me/edit/page.tsx
+++ b/src/app/profile/me/edit/page.tsx
@@ -5,18 +5,18 @@ import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
 
 import { checkAuthentication } from '@/utils/helpers';
 
-import EditProfile from '@/v1/profile/EditProfile';
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+import withAuthRequired from '@/hocs/withAuthRequired';
 
-/**
- * @todo
- * Fallback UI 추가하기
- */
+import EditProfile from '@/v1/profile/EditProfile';
+import Loading from '@/v1/base/Loading';
 
 const EditProfilePage = () => {
+  const AuthRequiredContents = withAuthRequired(Contents);
+
   return (
-    <SSRSafeSuspense fallback={null}>
-      <Contents />
+    <SSRSafeSuspense fallback={<Loading fullpage />}>
+      <AuthRequiredContents />
     </SSRSafeSuspense>
   );
 };

--- a/src/app/profile/me/group/page.tsx
+++ b/src/app/profile/me/group/page.tsx
@@ -26,9 +26,7 @@ const UserGroupPage = () => {
   );
 };
 
-const AuthRequiredUserGroupPage = withAuthRequired(UserGroupPage);
-
-export default AuthRequiredUserGroupPage;
+export default withAuthRequired(UserGroupPage);
 
 const UserGroupContent = () => {
   const isAuthenticated = checkAuthentication();

--- a/src/app/profile/me/group/page.tsx
+++ b/src/app/profile/me/group/page.tsx
@@ -4,6 +4,8 @@ import useMyGroupsQuery from '@/queries/group/useMyGroupQuery';
 import { checkAuthentication } from '@/utils/helpers';
 
 import SSRSafeSuspense from '@/components/SSRSafeSuspense';
+import withAuthRequired from '@/hocs/withAuthRequired';
+
 import BackButton from '@/v1/base/BackButton';
 import TopNavigation from '@/v1/base/TopNavigation';
 import DetailBookGroupCard from '@/v1/bookGroup/DetailBookGroupCard';
@@ -23,6 +25,10 @@ const UserGroupPage = () => {
     </>
   );
 };
+
+const AuthRequiredUserGroupPage = withAuthRequired(UserGroupPage);
+
+export default AuthRequiredUserGroupPage;
 
 const UserGroupContent = () => {
   const isAuthenticated = checkAuthentication();
@@ -64,8 +70,6 @@ const UserGroupContent = () => {
     </ul>
   );
 };
-
-export default UserGroupPage;
 
 const PageSkeleton = () => (
   <ul className="flex animate-pulse flex-col gap-[1rem] pt-[2rem]">

--- a/src/hocs/withAuthRequired.tsx
+++ b/src/hocs/withAuthRequired.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { checkAuthentication } from '@/utils/helpers';
+
+const withAuthRequired = <P extends object>(
+  WrappedComponent: React.ComponentType<P>
+) => {
+  const Component = (props: P) => {
+    const router = useRouter();
+
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+    useEffect(() => {
+      const hasAccessToken = checkAuthentication();
+
+      if (!hasAccessToken) {
+        router.push('/login');
+      } else {
+        setIsAuthenticated(hasAccessToken);
+      }
+    }, [router]);
+
+    if (!isAuthenticated) {
+      return null;
+    } else {
+      return <WrappedComponent {...props} />;
+    }
+  };
+
+  return Component;
+};
+
+export default withAuthRequired;

--- a/src/v1/profile/group/ProfileGroupContainer.tsx
+++ b/src/v1/profile/group/ProfileGroupContainer.tsx
@@ -1,6 +1,9 @@
 import useMyGroupsQuery from '@/queries/group/useMyGroupQuery';
 import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
-import { APIUser } from '@/types/user';
+import type { APIUser } from '@/types/user';
+
+import { checkAuthentication } from '@/utils/helpers';
+
 import ProfileGroupPresenter from './ProfileGroupPresenter';
 
 const ProfileGroupContainer = ({
@@ -8,7 +11,9 @@ const ProfileGroupContainer = ({
 }: {
   userId: 'me' | APIUser['userId'];
 }) => {
-  const { data } = useMyGroupsQuery();
+  const isAuthenticated = checkAuthentication();
+
+  const { data } = useMyGroupsQuery({ enabled: isAuthenticated });
   const {
     data: { userId: myId },
   } = useMyProfileQuery({ enabled: userId === 'me' });


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
### `withAuthRequired` 고차 컴포넌트
- 페이지 접근 권한을 부여하기 위한 고차 컴포넌트를 작성했어요
- 권한이 없을 시(비로그인 시) `/login` 페이지로 redirect 합니다.
- `Hydration` 에러를 해결하기 위해 내부에 `isAuthenticated`라는 `useState`를 정의했어요
(`isAuthenticated`가 `false`면 래핑된 컴포넌트는 `null`을 `return` 해요.)


# 스크린샷
https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/6d10bece-c33d-407a-98a8-912469b24f21



# 관련 이슈

- Close #608 
