### PR TITLE
[#612] 북카이브 페이지에서 발생하는 무한 리랜더링 버그 수정

### DIFF
--- a/src/app/bookarchive/page.tsx
+++ b/src/app/bookarchive/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import useMyProfileQuery from '@/queries/user/useMyProfileQuery';
+
 import { checkAuthentication } from '@/utils/helpers';
-import { Suspense } from 'react';
-import useMounted from '@/hooks/useMounted';
+
+import SSRSafeSuspense from '@/components/SSRSafeSuspense';
 import BookArchiveForAuth from '@/v1/bookArchive/BookArchiveForAuth';
 import BookArchiveForUnAuth from '@/v1/bookArchive/BookArchiveForUnAuth';
 import TopHeader from '@/v1/base/TopHeader';
@@ -13,9 +14,9 @@ export default function BookArchivePage() {
     <div className="flex w-full flex-col gap-[1rem] pb-[2rem]">
       <TopHeader text="BookArchive" />
       {/* TODO: 스켈레톤 컴포넌트로 교체 */}
-      <Suspense fallback={null}>
+      <SSRSafeSuspense fallback={null}>
         <Contents />
-      </Suspense>
+      </SSRSafeSuspense>
     </div>
   );
 }
@@ -25,8 +26,6 @@ const Contents = () => {
   const { data: userData } = useMyProfileQuery({
     enabled: isAuthenticated,
   });
-  const mounted = useMounted();
-  if (!mounted) return null;
 
   return isAuthenticated ? (
     <BookArchiveForAuth userJobGroup={userData.job.jobGroupName} />


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
로그인이된 상태의 북카이브 페이지에서 accessToken을 유효하지 않게 수정할 경우
무한 리랜더링이 되는 현상을 수정합니다.


# 관련 이슈

- Close #612 
