### PR TITLE
[#622] BottomActionButton 패딩 수정

### DIFF
--- a/src/app/book/[bookId]/page.tsx
+++ b/src/app/book/[bookId]/page.tsx
@@ -34,7 +34,7 @@ const BookDetailPage = ({
     <>
       <BookTopNavigation bookId={bookId} />
       <SSRSafeSuspense fallback={<BookPageSkeleton />}>
-        <div className="flex flex-col gap-[3rem] pb-[5rem] pt-[1rem]">
+        <div className="pb-action-button flex flex-col gap-[3rem] pt-[1rem]">
           <BookInfo bookId={bookId} />
           <div className="flex flex-col gap-[1rem]">
             <Heading text="책 코멘트" />

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -29,7 +29,7 @@ const DetailBookGroupPage = ({
       </BookGroupNavigation>
 
       <SSRSafeSuspense fallback={<PageSkeleton />}>
-        <div className="flex flex-col gap-[2rem]">
+        <div className="pb-action-button flex flex-col gap-[2rem]">
           <BookGroupInfo groupId={groupId} />
           <Divider />
           <div className="flex flex-col gap-[1rem]">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,6 +101,6 @@
    */
 
   .pb-action-button {
-    @apply pb-[calc(env(safe-area-inset-bottom)+7.3rem)];
+    @apply pb-[calc(env(safe-area-inset-bottom)+6.3rem)];
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,4 +94,13 @@
     box-shadow: inset 0 0 3rem #dddddd;
     @apply bg-placeholder;
   }
+
+  /*
+   * 그룹 상세
+   * 책 상세
+   */
+
+  .pb-action-button {
+    @apply pb-[calc(env(safe-area-inset-bottom)+7.3rem)];
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -95,11 +95,6 @@
     @apply bg-placeholder;
   }
 
-  /*
-   * 그룹 상세
-   * 책 상세
-   */
-
   .pb-action-button {
     @apply pb-[6.3rem];
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,6 +101,6 @@
    */
 
   .pb-action-button {
-    @apply pb-[calc(env(safe-area-inset-bottom)+6.3rem)];
+    @apply pb-[6.3rem];
   }
 }

--- a/src/v1/base/BottomActionButton.tsx
+++ b/src/v1/base/BottomActionButton.tsx
@@ -11,7 +11,7 @@ const BottomActionButton = ({
   ...props
 }: BottomActionButtonProps) => {
   return (
-    <footer className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-[43rem] bg-white px-[2.0rem] py-[1.5rem]">
+    <footer className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-[43rem] bg-white px-[2.0rem] pb-[calc(env(safe-area-inset-bottom)+1.5rem)] pt-[1.5rem]">
       <Button size="full" {...props}>
         {children}
       </Button>

--- a/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
+++ b/src/v1/bookGroup/create/steps/SelectJoinTypeStep/SelectJoinTypeStep.tsx
@@ -16,7 +16,7 @@ const SelectJoinTypeStep = ({ onSubmit }: MoveFunnelStepProps) => {
   } = useFormContext<SelectJoinTypeStepFormValues>();
 
   return (
-    <article>
+    <article className="pb-action-button">
       <h2 className="mb-[3rem] font-subheading-bold">
         가입은 어떻게 받을까요?
       </h2>

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -37,7 +37,7 @@ const SetUpDetailStep = ({
   } = useFormContext<SetUpDetailStepFormValues>();
 
   return (
-    <article className="flex flex-col gap-[2.5rem] overflow-y-scroll pb-[7rem]">
+    <article className="flex flex-col gap-[2.5rem] overflow-y-scroll pb-[calc(env(safe-area-inset-bottom)+7rem)]">
       <h2 className="font-subheading-bold">모임 정보를 설정해주세요</h2>
       <TitleField name={'title'} />
       <SelectedBookInfoField

--- a/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
+++ b/src/v1/bookGroup/create/steps/SetUpDetailStep/SetUpDetailStep.tsx
@@ -37,7 +37,7 @@ const SetUpDetailStep = ({
   } = useFormContext<SetUpDetailStepFormValues>();
 
   return (
-    <article className="flex flex-col gap-[2.5rem] overflow-y-scroll pb-[calc(env(safe-area-inset-bottom)+7rem)]">
+    <article className="pb-action-button flex flex-col gap-[2.5rem] overflow-y-scroll">
       <h2 className="font-subheading-bold">모임 정보를 설정해주세요</h2>
       <TitleField name={'title'} />
       <SelectedBookInfoField

--- a/src/v1/layout/Layout.tsx
+++ b/src/v1/layout/Layout.tsx
@@ -16,7 +16,7 @@ const Layout = ({ children }: LayoutProps) => {
 
   const dynamicClass = isRootPath
     ? 'pb-[calc(env(safe-area-inset-bottom)+7rem)] pt-[2rem]'
-    : 'pt-[5.4rem] pb-[2rem]';
+    : 'pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-[5.4rem]';
 
   return (
     <>


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

PWA환경에서 스마트폰 기본 UI와의 간섭을 제거하기위해
`BottomActionButton`에 `padding-bottom`값을 수정하였습니다.

수정된 `BottomActionButton`의 `padding-bottom`값으로 인해
컨탠츠 하단부가 가려지는 현상을 `.pb-action-button` 커스텀 클래스를 작성하여 해결하였습니다.


# 관련 이슈

- Close #622 
