### PR TITLE
[#625] Toast 컴포넌트 icon이 잘리는 문제 해결

### DIFF
--- a/public/icons/check-circle.svg
+++ b/public/icons/check-circle.svg
@@ -1,8 +1,6 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_3483_5490)">
-<circle cx="10" cy="10" r="9" fill="#70B681" stroke="#70B681" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="10" cy="10" r="10" fill="#70B681"/>
 <path d="M5 11L8 14L15 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
 <defs>
 <clipPath id="clip0_3483_5490">
 <rect width="20" height="20" fill="white"/>

--- a/public/icons/error-circle.svg
+++ b/public/icons/error-circle.svg
@@ -1,9 +1,7 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_3483_5493)">
-<circle cx="10" cy="10" r="9" fill="#F56565" stroke="#F56565" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="10" cy="10" r="10" fill="#F56565"/>
 <path d="M7 7L13 13" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M13 7L7 13" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
 <defs>
 <clipPath id="clip0_3483_5493">
 <rect width="20" height="20" fill="white"/>

--- a/public/icons/warning-circle.svg
+++ b/public/icons/warning-circle.svg
@@ -1,9 +1,7 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_3483_5497)">
-<circle cx="10" cy="10" r="9" fill="#FECB16" stroke="#FECB16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="10" cy="13" r="1" fill="black"/>
+<circle cx="10" cy="10" r="10" fill="#FECB16"/>
+<circle cx="10" cy="14" r="1" fill="black"/>
 <path d="M10 6L10 10" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
 <defs>
 <clipPath id="clip0_3483_5497">
 <rect width="20" height="20" fill="white"/>


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- Toast svg 아이콘에서 불필요한 clip path 요소를 제거했어요.
<!-- - ex) 결제 기능 구현 -->

# 스크린샷
- 확인을 위해 toast 타입을 수정해서 캡처했어요!

<img width="300" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/5d4a6caa-a5d9-434c-973e-337fd6383b4f" />

<img width="300" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/4a6a3e05-0d32-4906-98c0-a170c15efd5c" />

<img width="300" src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/4b381df9-fd92-4d78-9cb0-f48f937968ee" />

# 관련 이슈

- Close #625 <!--이슈번호-->
