### PR TITLE
[#641] 메타데이터를 dev.dadok.app 도메인 기준으로 수정

### DIFF
--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -41,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${process.env.NEXT_PUBLIC_HOST}/book/${value}`,
+    url: `${process.env.NEXT_HOST}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -34,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${process.env.NEXT_PUBLIC_HOST}/bookshelf/${bookshelfId}`,
+    url: `${process.env.NEXT_HOST}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   verification: {
     google: '72kN3MWyQHuvSb8V67dVkfPUPMrw102Tm6BsvTvfKmg',
     other: {
-      'naver-site-verification': '9046af5eda448309a92e2e923a45cb874df986a0',
+      'naver-site-verification': 'd838b57100508b70db53a7d15014627456c5ac28',
     },
   },
   icons: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,17 +17,6 @@ export const metadata: Metadata = {
   },
   description: '책에 대한 인사이트를 공유하고 소통하는 독서 소셜 플랫폼',
   themeColor: '#FFFFFF',
-  keywords: [
-    '다독다독',
-    'dadok',
-    'dadokdadok',
-    '책장',
-    '책추천',
-    '도서검색',
-    '독서모임',
-    '책',
-    '독서',
-  ],
   viewport:
     'minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, viewport-fit=cover',
   verification: {


### PR DESCRIPTION
# 구현 내용
### 사이트 소유권 value값 수정
- 도메인 주소를 `dadok.app`에서 `dev.dadok.app`으로 fix하면서 사이트 소유권 value값이 변경됐어요


### `sitemap.ts`에 잘못 기입된 env값 수정
- 몇몇 `sitemap.ts`에서 환경변수가 잘못 기입되어있던 부분을 수정했어요


### `metadata`에서 `keywords` 제거
- **_더 이상 구글과 네이버과 같은 검색엔진에서는 metadata의 keywords를 검색 대상에 반영하고 있지않다._** 라는 점을 참고했어요
해당 내용은 불필요하다고 판단하여 삭제하였습니다.

> 메타 키워드는 과거에 웹 페이지를 구별하기 위한 요소로 사용되었으나, 여러 사이트 운영자가 이 점을 악용하여 검색되는 내용과 실제 내용이 다른 페이지가 검색되는 일이 빈번하게 발생하기 시작했습니다.
이 같은 문제로 현재는 거의 모든 검색엔진에서 메타 키워드를 검색 대상에 반영하지 않고 있으며, 반영하더라도 그 비중은 매우 낮을 것으로 추정됩니다. [본문 링크](https://imweb.me/faq?mode=view&category=29&category2=35&idx=28244)

# 관련 이슈

- Close #641 
