### PR TITLE
[#640] 로그인하지 않은 사용자의 진입점을 로그인 페이지로 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,15 +42,6 @@ const nextConfig = {
       },
     ];
   },
-  async redirects() {
-    return [
-      {
-        source: '/',
-        destination: '/bookarchive',
-        permanent: false,
-      },
-    ];
-  },
   images: {
     remotePatterns: [
       {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,6 +17,7 @@ const LoginPage = () => {
           alt="로그인랜딩이미지"
           width={300}
           height={270}
+          priority
         />
         <p className="text-center !leading-snug font-heading-regular">
           <span className="font-subheading-regular">
@@ -28,7 +29,7 @@ const LoginPage = () => {
         </p>
       </article>
 
-      <section className="absolute inset-x-[2rem] bottom-[2rem] flex flex-col justify-center gap-[1rem]">
+      <section className="absolute inset-x-[2rem] bottom-[calc(env(safe-area-inset-bottom)+2rem)] mx-auto flex max-w-[41rem] flex-col justify-center gap-[1rem]">
         <Link href={KAKAO_LOGIN_URL}>
           <Button size="full" colorScheme="kakao">
             <div className="flex w-full items-center justify-center">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,7 +37,7 @@ const LoginPage = () => {
             </div>
           </Button>
         </Link>
-        <Link href="/" className="flex justify-center">
+        <Link href="/bookarchive" className="flex justify-center">
           <Button
             size="small"
             colorScheme="grey"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export const config = {
+  matcher: ['/'],
+};
+
+export async function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.match('/')) {
+    /**
+     * '/' 로 접근하는 경우, 아래 조건에 따라 redirect
+     * cookie에 RefreshToken이 존재하면 /bookarchive
+     * cookie에 RefreshToken이 없으면 /login
+     */
+
+    if (request.cookies.has('RefreshToken')) {
+      console.log('has refreshToken', request.cookies);
+      request.nextUrl.pathname = '/bookarchive';
+    } else {
+      request.nextUrl.pathname = '/login';
+    }
+
+    return NextResponse.redirect(request.nextUrl);
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,7 +14,6 @@ export async function middleware(request: NextRequest) {
      */
 
     if (request.cookies.has('RefreshToken')) {
-      console.log('has refreshToken', request.cookies);
       request.nextUrl.pathname = '/bookarchive';
     } else {
       request.nextUrl.pathname = '/login';


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- 루트 path '/' 로 접근한 경우, middleware를 통해 쿠키의 refreshToken 유무에 따라 다른 경로로 리다이렉팅되도록 수정했어요.
  - refreshToken이 존재하는 경우, `/bookarchive` 로 리다이렉팅
  - refreshToken이 없는 경우, `/login` 로 리다이렉팅

<!-- - ex) 결제 기능 구현 -->

# 스크린샷
<img src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/57716832/3d33ce32-cc36-466a-a47c-8c349dc72dd7" width="320" />


<!-- 없는 경우 생략한다. -->

# 관련 이슈

- Close #640 <!--이슈번호-->
