### PR TITLE
[#650] 구글 애널리틱스 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@storybook/react": "^7.0.26",
     "@storybook/testing-library": "^0.0.14-next.2",
     "@svgr/webpack": "^6.5.1",
+    "@types/gtag.js": "^0.0.20",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.61.0",
     "autoprefixer": "^10.4.14",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 
 import { appleSplashScreens } from '@/constants/metadata';
 
+import GoogleAnalytics from '@/components/common/GoogleAnalytics';
 import ContextProvider from '@/components/common/ContextProvider';
 import AuthFailedErrorBoundary from '@/components/common/AuthFailedErrorBoundary';
 import Layout from '@/components/layout/Layout';
@@ -39,6 +40,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ko">
       <body className={`${LineSeedKR.variable} app-layout font-lineseed`}>
+        <GoogleAnalytics />
         <Layout>
           <ContextProvider>
             <AuthFailedErrorBoundary>{children}</AuthFailedErrorBoundary>

--- a/src/components/common/GoogleAnalytics.tsx
+++ b/src/components/common/GoogleAnalytics.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Script from 'next/script';
+
+import * as gtag from '@/utils/gtag';
+
+const GoogleAnalytics = () => {
+  return (
+    <>
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
+      />
+      <Script
+        id="gtag-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${gtag.GA_TRACKING_ID}', {
+            page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
+    </>
+  );
+};
+
+export default GoogleAnalytics;

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -1,0 +1,22 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GOOGLE_ID;
+
+type GTagEventTypes = {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+};
+
+export const pageview = (url: string) => {
+  window.gtag('config', GA_TRACKING_ID as string, {
+    page_path: url,
+  });
+};
+
+export const event = ({ action, category, label, value }: GTagEventTypes) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,6 +3631,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.20.tgz#e47edabb4ed5ecac90a079275958e6c929d7c08a"
+  integrity sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz"


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
### 구글 애널리틱스를 추가했어요
개르발민족 계정의 구글 애널리틱스 페이지에서 통계를 확인해 볼 수 있어요!
개르발민족 계정 로그인 이후 [여기에서](https://analytics.google.com/analytics/web/?pli=1#/p448011325/reports/intelligenthome?params=_u..nav%3Dmaui) 확인할 수 있어요!

해당 [미디엄 블로그](https://dany-rivera.medium.com/how-to-integrate-google-analytics-on-your-next-js-13-app-easy-guide-c7389666831c)의 내용을 참고하여 구현하였습니다.

# pr 포인트
### 동작 방식
1. `utils/gtag.ts`의 `event`와 `pageview` 함수를 통해 페이지가 몇 번 노출되었는지, 이벤트들은 얼마나 동작하였는지 수집해요.
2. `GoogleAnalytics.tsx`컴포넌트에 `gtag.ts` 유틸들을 일괄적으로 import하고 script를 작성해요
3. 최종적으로 `Layout.tsx`에 `GoogleAnalytics.tsx`를 삽입하여 이벤트와 페이지 노출 횟수와 같은 자료를 구글에 전달해요.
<img src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/ad035085-a467-474b-b173-48838b10eeb9" width="720" />

### 바뀐점
- `devDependencies`에 `@types/gtag.js`가 추가되었어요.
- ~~`release` 프로덕션 브랜치에 머지되면 GA가 최종 작동합니다!~~
dadok.app 도메인 모두 통계자료에 집계되고있네요.. 😅


# 관련 이슈

- Close #650 <!--이슈번호-->
