### PR TITLE
[#657] 네비게이션 스키마 작성

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,13 @@
 import type { Metadata } from 'next';
 
-import {
-  appleSplashScreens,
-  navigationSchemaItems,
-} from '@/constants/metadata';
+import { appleSplashScreens } from '@/constants/metadata';
 
 import GoogleAnalytics from '@/components/common/GoogleAnalytics';
 import AuthFailedErrorBoundary from '@/components/common/AuthFailedErrorBoundary';
 import PWAServiceWorkerProvider from '@/components/common/PWAServiceWorkerProvider';
 import ReactQueryProvider from '@/components/common/ReactQueryProvider';
 import ToastProvider from '@/components/common/Toast/ToastProvider';
+import NavigationSchemaScript from '@/components/common/NavigationSchemaScript';
 import Layout from '@/components/layout/Layout';
 
 import { LineSeedKR } from '@/styles/font';
@@ -41,12 +39,6 @@ export const metadata: Metadata = {
   },
 };
 
-const navigationSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'ItemList',
-  itemListElement: navigationSchemaItems,
-};
-
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ko">
@@ -61,10 +53,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
             </ReactQueryProvider>
           </ToastProvider>
         </PWAServiceWorkerProvider>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(navigationSchema) }}
-        />
+        <NavigationSchemaScript />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
 
-import { appleSplashScreens } from '@/constants/metadata';
+import {
+  appleSplashScreens,
+  navigationSchemaItems,
+} from '@/constants/metadata';
 
 import GoogleAnalytics from '@/components/common/GoogleAnalytics';
 import AuthFailedErrorBoundary from '@/components/common/AuthFailedErrorBoundary';
@@ -38,6 +41,12 @@ export const metadata: Metadata = {
   },
 };
 
+const navigationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: navigationSchemaItems,
+};
+
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ko">
@@ -52,6 +61,10 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
             </ReactQueryProvider>
           </ToastProvider>
         </PWAServiceWorkerProvider>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(navigationSchema) }}
+        />
       </body>
     </html>
   );

--- a/src/components/common/NavigationSchemaScript.tsx
+++ b/src/components/common/NavigationSchemaScript.tsx
@@ -1,0 +1,21 @@
+import Script from 'next/script';
+
+import { navigationSchemaItems } from '@/constants/metadata/schema';
+
+const navigationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: navigationSchemaItems,
+};
+
+const NavigationSchemaScript = () => {
+  return (
+    <Script
+      id="navigation-schema"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(navigationSchema) }}
+    />
+  );
+};
+
+export default NavigationSchemaScript;

--- a/src/constants/metadata/appleSplashScreens.ts
+++ b/src/constants/metadata/appleSplashScreens.ts
@@ -1,4 +1,4 @@
-const appleSplashScreens = [
+export const appleSplashScreens = [
   {
     rel: 'apple-touch-startup-image',
     media:
@@ -228,5 +228,3 @@ const appleSplashScreens = [
     url: '/images/splash-screens/8.3__iPad_Mini_portrait.png',
   },
 ];
-
-export default appleSplashScreens;

--- a/src/constants/metadata/index.ts
+++ b/src/constants/metadata/index.ts
@@ -1,1 +1,2 @@
-export { default as appleSplashScreens } from './appleSplashScreens';
+export * from './appleSplashScreens';
+export * from './schema';

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -1,0 +1,35 @@
+const baseUrl = new URL(`${process.env.NEXT_HOST}`);
+
+export const navigationSchemaItems = [
+  {
+    '@type': 'SiteNavigationElement',
+    position: 1,
+    name: '북카이브',
+    description:
+      '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
+    url: `${baseUrl}bookarchive`,
+  },
+  {
+    '@type': 'SiteNavigationElement',
+    position: 2,
+    name: '도서검색',
+    description:
+      '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
+    url: `${baseUrl}book/search`,
+  },
+  {
+    '@type': 'SiteNavigationElement',
+    position: 3,
+    name: '독서모임',
+    description:
+      '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
+    url: `${baseUrl}group`,
+  },
+  {
+    '@type': 'SiteNavigationElement',
+    position: 4,
+    name: '내프로필',
+    description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
+    url: `${baseUrl}profile/me`,
+  },
+];


### PR DESCRIPTION
# 구현 내용
<img src="https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/dfad9178-51ee-4dcf-92db-52edc3002faf" width="360" />

위 이미지는 구글에 "당근"을 검색했을때 나오는 UI예요.

"당근" 검색 결과 처럼 "다독다독"을 검색했을때 저희 서비스가 노출된다면
북카이브, 도서검색, 독서모임, 내프로필 4가지 항목이 보일 수 있도록 네비게이션 스키마를 작성했어요


# 스크린샷
https://github.com/prgrms-web-devcourse/Team-Gaerval-Dadok-FE/assets/73218463/ebb61aa7-b7d8-4bf7-ad85-2bc42bf837c6

[schema.org](https://validator.schema.org/)에서 네비게이션 스키마 마크업이
올바르게 적용됐는지 테스트하는 영상이에요


# Help
### 각 항목에 대한 `description`
`constants/metadata/scheme.ts`에 각 항목에 대한 description을 임시로 제가 적어 두었어요.
- 북카이브: 같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요
- 도서검색: 평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요
- 독서모임: 읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요
- 내프로필: 내 책장을 관리하고 참여한 독서 모임들을 확인해보세요

더 자연스럽거나 어울리는 문구가 있다면 적어주셔도 좋아요 🤣 


# 관련 이슈
- Close #657 