### PR TITLE
[#665] [도서 검색] 최근 검색어 존재하지 않을때 UI 수정

### DIFF
--- a/src/components/bookSearch/RecentSearchList.tsx
+++ b/src/components/bookSearch/RecentSearchList.tsx
@@ -9,10 +9,12 @@ type RecentSearchListProps = {
 };
 
 const RecentSearchList = ({ keywords, onClick }: RecentSearchListProps) => {
+  const hasKeywords = keywords && keywords?.length !== 0;
+
   return (
     <section className="flex flex-col gap-[1.5rem]">
       <h2 className="font-body1-regular">최근 검색어</h2>
-      {keywords ? (
+      {hasKeywords ? (
         <ul className="relative flex w-[calc(100%+2rem)] gap-[1rem] overflow-x-scroll whitespace-nowrap pb-[1rem]">
           {keywords.map(item => (
             <li key={`${item.keyword}-${item.modifiedAt}`}>


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용

로그인한 사용자의
최근 검색어가 존재하지 않을 때
"검색 기록이 없어요!" 문구가 보이도록
수정했어요!

# 스크린샷
### 변경 전
<img width="430" alt="image" src="https://github.com/user-attachments/assets/d17b58c6-02a0-4c1a-a478-42573b81847e">

### 변경 후
<img width="430" alt="image" src="https://github.com/user-attachments/assets/0c70afed-84cc-432e-b7f2-66c2ba6d399d">


# pr 포인트

```tsx
const hasKeywords = keywords && keywords?.length !== 0;

...

return (
  {hasKeywords ? (
    <최근검색어 />
  ) : (
    <p>검색 기록이 없어요!</p>
  )
)
```

기존의 버그는 `props`로 받아오는 `keywords`가 빈배열 `[]`일 경우에도
`boolean`값이 `true`이기 때문에 발생한 버그였어요

`hasKeyword`라는 `boolean` 형태의 변수를 만들어 해결했어요

# 관련 이슈

- Close #665 
