### PR TITLE
[#667] [북카이브] 유저 로그인 상태의 북카이브 UI 수정

### DIFF
--- a/src/app/bookarchive/page.tsx
+++ b/src/app/bookarchive/page.tsx
@@ -27,7 +27,9 @@ const Contents = () => {
     enabled: isAuthenticated,
   });
 
-  return isAuthenticated ? (
+  const hasProfile = isAuthenticated && userData?.job?.jobGroupName;
+
+  return hasProfile ? (
     <BookArchiveForAuth userJobGroup={userData.job.jobGroupName} />
   ) : (
     <BookArchiveForUnAuth />

--- a/src/components/bookArchive/BookArchiveForAuth.tsx
+++ b/src/components/bookArchive/BookArchiveForAuth.tsx
@@ -37,7 +37,7 @@ const BookArchiveForAuth = ({
   return (
     <div className="flex w-full flex-col gap-[1.5rem] font-body1-bold">
       <h2>👀 이런 책들이 많이 꽂혔어요</h2>
-      <ul className="flex gap-[1.5rem] overflow-auto pb-[1.5rem]">
+      <ul className="flex w-[calc(100%+2rem)] gap-[1.5rem] overflow-auto pb-[1.5rem]">
         {booksData.books.map(({ bookId, imageUrl, title }) => (
           <li key={bookId} className="max-w-[9rem]">
             <Link href={`/book/${bookId}`} className="flex flex-col gap-[1rem]">


### PR DESCRIPTION
# 구현 내용
### 프로필 정보가 없는 유저가 로그인한 상태에 북카이브에 접근했을 때
- 미들웨어에서 `profile/me/add`로 리다이렉팅 시켜주고있어요
- 이전 처럼 리다이렉팅 되지 않는다면 유저는 텅 빈 북카이브를 보게 되요
- **프로필 정보가 없다면 `BookarchiveForUnAuth` 컴포넌트를 보여주도록 수정했어요**

### 로그인 상태의 북카이브 추천 도서 스크롤 UI 수정
- **`추천 도서 리스트` 컴포넌트 오른쪽 너비를 오른쪽 화면 끝까지 이어지도록 수정했어요**


# 스크린샷
### 적용 전
<img width="430" alt="image" src="https://github.com/user-attachments/assets/29c6d219-654f-4a46-9ff9-08eb48742e40">


### 적용 후
<img width="430" alt="image" src="https://github.com/user-attachments/assets/bc9f11ad-c573-499c-94f7-679b696ff2ee">


# Help
이전에도 이야기했던 내용인데 `430px`이상의 크기로 화면을 보았을 때
`BookCover` 컴포넌트가 애매하게 안짤리고 있어서(?) 스크롤인지 모를 수도 있을 것 같아요
`BookCover` 컴포넌트를 수정하는게 좋을지 혹은 이곳에 스크롤인지 알 수 있도록 다른 UI를 추가해야할지 고민이네요 🤔 

~~몇 가지 레퍼런스들을 찾아보고 코멘트에 남겨볼게요..!~~
만약 `BookCover` 컴포넌트는 그대로 두고, 가이드 UI를 추가한다면 해당 레퍼런스를 참고해볼 수 있을 것 같아요!
### 토스 증권 랜딩페이지 [링크](https://tossinvest.com/)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2e9704f5-1bd0-46c9-bb5a-c5334685d081">

### 지그재그 랜딩 페이지 [링크](https://zigzag.kr/)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2a80e27a-ca7a-4739-a2e6-5596eef960f3">

### 리디북스 랜딩 페이지 [링크](https://ridibooks.com/webtoon/recommendation)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4a0b3dbb-8e5d-438a-8f53-a05f7acbb89f">



# 관련 이슈

- Close #667 
