### PR TITLE
[#677] metadata에 프로덕션 URL만 노출되도록 수정

### DIFF
--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next';
 import type { APIRecommendedBookshelf } from '@/types/bookshelf';
 import type { APIBook } from '@/types/book';
+import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -41,7 +42,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${process.env.NEXT_HOST}/book/${value}`,
+    url: `${DEPLOYMENT_URL}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from 'next';
 import type { APIRecommendedBookshelf } from '@/types/bookshelf';
 import type { APIBook } from '@/types/book';
-import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -42,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${DEPLOYMENT_URL}/book/${value}`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -41,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/${value}`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -41,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${process.env.NEXT_PRODUCTION_URL}/book/${value}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/book/sitemap.ts
+++ b/src/app/book/sitemap.ts
@@ -41,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemap = ['search', ...booksId];
 
   return sitemap.map(value => ({
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/book/${value}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/${value}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -34,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/bookshelf/${bookshelfId}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from 'next';
 import type { APIRecommendedBookshelf } from '@/types/bookshelf';
-import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -35,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${DEPLOYMENT_URL}/bookshelf/${bookshelfId}`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -34,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${process.env.NEXT_PRODUCTION_URL}/bookshelf/${bookshelfId}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -34,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookshelf/${bookshelfId}`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/bookshelf/sitemap.ts
+++ b/src/app/bookshelf/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next';
 import type { APIRecommendedBookshelf } from '@/types/bookshelf';
+import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -34,7 +35,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookshelves = await bookshelvesSitemap();
 
   return bookshelves.map(({ bookshelfId }) => ({
-    url: `${process.env.NEXT_HOST}/bookshelf/${bookshelfId}`,
+    url: `${DEPLOYMENT_URL}/bookshelf/${bookshelfId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/group/sitemap.ts
+++ b/src/app/group/sitemap.ts
@@ -32,7 +32,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookGroups = await bookGroupSitemap();
 
   return bookGroups.map(bookGroupId => ({
-    url: `${process.env.NEXT_PRODUCTION_URL}/group/${bookGroupId}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group/${bookGroupId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/group/sitemap.ts
+++ b/src/app/group/sitemap.ts
@@ -32,7 +32,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookGroups = await bookGroupSitemap();
 
   return bookGroups.map(bookGroupId => ({
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group/${bookGroupId}`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/group/${bookGroupId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/group/sitemap.ts
+++ b/src/app/group/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from 'next';
 import type { APIGroupPagination } from '@/types/group';
-import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -33,7 +32,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookGroups = await bookGroupSitemap();
 
   return bookGroups.map(bookGroupId => ({
-    url: `${DEPLOYMENT_URL}/group/${bookGroupId}`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/group/${bookGroupId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/group/sitemap.ts
+++ b/src/app/group/sitemap.ts
@@ -32,7 +32,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookGroups = await bookGroupSitemap();
 
   return bookGroups.map(bookGroupId => ({
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/group/${bookGroupId}`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group/${bookGroupId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/group/sitemap.ts
+++ b/src/app/group/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next';
 import type { APIGroupPagination } from '@/types/group';
+import { DEPLOYMENT_URL } from '@/constants/url';
 
 const options = {
   headers: {
@@ -32,7 +33,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const bookGroups = await bookGroupSitemap();
 
   return bookGroups.map(bookGroupId => ({
-    url: `${process.env.NEXT_HOST}/group/${bookGroupId}`,
+    url: `${DEPLOYMENT_URL}/group/${bookGroupId}`,
     lastModified: new Date(),
   }));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import { LineSeedKR } from '@/styles/font';
 import '@/styles/global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${process.env.NEXT_DEPLOYMENT_URL}`),
+  metadataBase: new URL(`${process.env.NEXT_PUBLIC_PRODUCTION_URL}`),
   title: {
     template: '%s | 다독다독',
     default: '다독다독',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import { LineSeedKR } from '@/styles/font';
 import '@/styles/global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${process.env.NEXT_PUBLIC_PRODUCTION_URL}`),
+  metadataBase: new URL(`${process.env.NEXT_PRODUCTION_URL}`),
   title: {
     template: '%s | 다독다독',
     default: '다독다독',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { appleSplashScreens } from '@/constants/metadata';
+import { DEPLOYMENT_URL } from '@/constants/url';
 
 import GoogleAnalytics from '@/components/common/GoogleAnalytics';
 import AuthFailedErrorBoundary from '@/components/common/AuthFailedErrorBoundary';
@@ -14,7 +15,7 @@ import { LineSeedKR } from '@/styles/font';
 import '@/styles/global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${process.env.NEXT_HOST}`),
+  metadataBase: new URL(`${DEPLOYMENT_URL}`),
   title: {
     template: '%s | 다독다독',
     default: '다독다독',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 
 import { appleSplashScreens } from '@/constants/metadata';
-import { DEPLOYMENT_URL } from '@/constants/url';
 
 import GoogleAnalytics from '@/components/common/GoogleAnalytics';
 import AuthFailedErrorBoundary from '@/components/common/AuthFailedErrorBoundary';
@@ -15,7 +14,7 @@ import { LineSeedKR } from '@/styles/font';
 import '@/styles/global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${DEPLOYMENT_URL}`),
+  metadataBase: new URL(`${process.env.NEXT_DEPLOYMENT_URL}`),
   title: {
     template: '%s | 다독다독',
     default: '다독다독',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import { LineSeedKR } from '@/styles/font';
 import '@/styles/global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${process.env.NEXT_PRODUCTION_URL}`),
+  metadataBase: new URL(`${process.env.NEXT_PUBLIC_PRODUCTION_URL}`),
   title: {
     template: '%s | 다독다독',
     default: '다독다독',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${process.env.NEXT_DEPLOYMENT_URL}/sitemap.xml`,
-    host: `${process.env.NEXT_DEPLOYMENT_URL}`,
+    sitemap: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/sitemap.xml`,
+    host: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}`,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/sitemap.xml`,
-    host: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}`,
+    sitemap: `${process.env.NEXT_PRODUCTION_URL}/sitemap.xml`,
+    host: `${process.env.NEXT_PRODUCTION_URL}`,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,14 +1,12 @@
 import type { MetadataRoute } from 'next';
 
-import { DEPLOYMENT_URL } from '@/constants/url';
-
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${DEPLOYMENT_URL}/sitemap.xml`,
-    host: `${DEPLOYMENT_URL}`,
+    sitemap: `${process.env.NEXT_DEPLOYMENT_URL}/sitemap.xml`,
+    host: `${process.env.NEXT_DEPLOYMENT_URL}`,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,12 +1,14 @@
 import type { MetadataRoute } from 'next';
 
+import { DEPLOYMENT_URL } from '@/constants/url';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${process.env.NEXT_HOST}/sitemap.xml`,
-    host: `${process.env.NEXT_HOST}`,
+    sitemap: `${DEPLOYMENT_URL}/sitemap.xml`,
+    host: `${DEPLOYMENT_URL}`,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${process.env.NEXT_PRODUCTION_URL}/sitemap.xml`,
-    host: `${process.env.NEXT_PRODUCTION_URL}`,
+    sitemap: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/sitemap.xml`,
+    host: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,15 +7,15 @@ import { default as bookGroupSitemap } from './group/sitemap';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
-      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
+      url: `${process.env.NEXT_PRODUCTION_URL}/bookarchive`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
+      url: `${process.env.NEXT_PRODUCTION_URL}/group`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
+      url: `${process.env.NEXT_PRODUCTION_URL}/profile/me`,
       lastModified: new Date(),
     },
     ...(await bookSitemap()),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,15 +7,15 @@ import { default as bookGroupSitemap } from './group/sitemap';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
-      url: `${process.env.NEXT_PRODUCTION_URL}/bookarchive`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_PRODUCTION_URL}/group`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_PRODUCTION_URL}/profile/me`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
       lastModified: new Date(),
     },
     ...(await bookSitemap()),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,15 +7,15 @@ import { default as bookGroupSitemap } from './group/sitemap';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
-      url: `${process.env.NEXT_DEPLOYMENT_URL}/bookarchive`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_DEPLOYMENT_URL}/group`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_DEPLOYMENT_URL}/profile/me`,
+      url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
       lastModified: new Date(),
     },
     ...(await bookSitemap()),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { DEPLOYMENT_URL } from '@/constants/url';
 import type { MetadataRoute } from 'next';
 
 import { default as bookSitemap } from './book/sitemap';
@@ -7,15 +8,15 @@ import { default as bookGroupSitemap } from './group/sitemap';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
-      url: `${process.env.NEXT_HOST}/bookarchive`,
+      url: `${DEPLOYMENT_URL}/bookarchive`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_HOST}/group`,
+      url: `${DEPLOYMENT_URL}/group`,
       lastModified: new Date(),
     },
     {
-      url: `${process.env.NEXT_HOST}/profile/me`,
+      url: `${DEPLOYMENT_URL}/profile/me`,
       lastModified: new Date(),
     },
     ...(await bookSitemap()),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,3 @@
-import { DEPLOYMENT_URL } from '@/constants/url';
 import type { MetadataRoute } from 'next';
 
 import { default as bookSitemap } from './book/sitemap';
@@ -8,15 +7,15 @@ import { default as bookGroupSitemap } from './group/sitemap';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
-      url: `${DEPLOYMENT_URL}/bookarchive`,
+      url: `${process.env.NEXT_DEPLOYMENT_URL}/bookarchive`,
       lastModified: new Date(),
     },
     {
-      url: `${DEPLOYMENT_URL}/group`,
+      url: `${process.env.NEXT_DEPLOYMENT_URL}/group`,
       lastModified: new Date(),
     },
     {
-      url: `${DEPLOYMENT_URL}/profile/me`,
+      url: `${process.env.NEXT_DEPLOYMENT_URL}/profile/me`,
       lastModified: new Date(),
     },
     ...(await bookSitemap()),

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -5,7 +5,7 @@ export const navigationSchemaItems = [
     name: '북카이브',
     description:
       '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
-    url: `${process.env.NEXT_PRODUCTION_URL}/bookarchive`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -13,7 +13,7 @@ export const navigationSchemaItems = [
     name: '도서검색',
     description:
       '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
-    url: `${process.env.NEXT_PRODUCTION_URL}/book/search`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/search`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -21,13 +21,13 @@ export const navigationSchemaItems = [
     name: '독서모임',
     description:
       '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
-    url: `${process.env.NEXT_PRODUCTION_URL}/group`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
   },
   {
     '@type': 'SiteNavigationElement',
     position: 4,
     name: '내프로필',
     description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
-    url: `${process.env.NEXT_PRODUCTION_URL}/profile/me`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
   },
 ];

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -1,4 +1,4 @@
-const baseUrl = new URL(`${process.env.NEXT_HOST}`);
+import { DEPLOYMENT_URL } from '@/constants/url';
 
 export const navigationSchemaItems = [
   {
@@ -7,7 +7,7 @@ export const navigationSchemaItems = [
     name: '북카이브',
     description:
       '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
-    url: `${baseUrl}bookarchive`,
+    url: `${DEPLOYMENT_URL}/bookarchive`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -15,7 +15,7 @@ export const navigationSchemaItems = [
     name: '도서검색',
     description:
       '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
-    url: `${baseUrl}book/search`,
+    url: `${DEPLOYMENT_URL}/book/search`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -23,13 +23,13 @@ export const navigationSchemaItems = [
     name: '독서모임',
     description:
       '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
-    url: `${baseUrl}group`,
+    url: `${DEPLOYMENT_URL}/group`,
   },
   {
     '@type': 'SiteNavigationElement',
     position: 4,
     name: '내프로필',
     description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
-    url: `${baseUrl}profile/me`,
+    url: `${DEPLOYMENT_URL}/profile/me`,
   },
 ];

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -5,7 +5,7 @@ export const navigationSchemaItems = [
     name: '북카이브',
     description:
       '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/bookarchive`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -13,7 +13,7 @@ export const navigationSchemaItems = [
     name: '도서검색',
     description:
       '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/search`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/book/search`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -21,13 +21,13 @@ export const navigationSchemaItems = [
     name: '독서모임',
     description:
       '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/group`,
   },
   {
     '@type': 'SiteNavigationElement',
     position: 4,
     name: '내프로필',
     description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
-    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
+    url: `${process.env.NEXT_PRODUCTION_URL}/profile/me`,
   },
 ];

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -5,7 +5,7 @@ export const navigationSchemaItems = [
     name: '북카이브',
     description:
       '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/bookarchive`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/bookarchive`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -13,7 +13,7 @@ export const navigationSchemaItems = [
     name: '도서검색',
     description:
       '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/book/search`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/book/search`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -21,13 +21,13 @@ export const navigationSchemaItems = [
     name: '독서모임',
     description:
       '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/group`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/group`,
   },
   {
     '@type': 'SiteNavigationElement',
     position: 4,
     name: '내프로필',
     description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
-    url: `${process.env.NEXT_DEPLOYMENT_URL}/profile/me`,
+    url: `${process.env.NEXT_PUBLIC_PRODUCTION_URL}/profile/me`,
   },
 ];

--- a/src/constants/metadata/schema.ts
+++ b/src/constants/metadata/schema.ts
@@ -1,5 +1,3 @@
-import { DEPLOYMENT_URL } from '@/constants/url';
-
 export const navigationSchemaItems = [
   {
     '@type': 'SiteNavigationElement',
@@ -7,7 +5,7 @@ export const navigationSchemaItems = [
     name: '북카이브',
     description:
       '같은 직군인 유저들의 책장과 인기 도서를 추천받고 인사이트를 넓혀보세요',
-    url: `${DEPLOYMENT_URL}/bookarchive`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/bookarchive`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -15,7 +13,7 @@ export const navigationSchemaItems = [
     name: '도서검색',
     description:
       '평소에 궁금했거나 함께 이야기 나누고 싶은 도서를 검색해보세요',
-    url: `${DEPLOYMENT_URL}/book/search`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/book/search`,
   },
   {
     '@type': 'SiteNavigationElement',
@@ -23,13 +21,13 @@ export const navigationSchemaItems = [
     name: '독서모임',
     description:
       '읽고 싶은 책을 선정하고 모임에 참여하여 멤버들과 이야기를 나눠보세요',
-    url: `${DEPLOYMENT_URL}/group`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/group`,
   },
   {
     '@type': 'SiteNavigationElement',
     position: 4,
     name: '내프로필',
     description: '내 책장을 관리하고 참여한 독서 모임들을 확인해보세요',
-    url: `${DEPLOYMENT_URL}/profile/me`,
+    url: `${process.env.NEXT_DEPLOYMENT_URL}/profile/me`,
   },
 ];

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -4,5 +4,3 @@ export const DATA_URL = {
 };
 
 export const KAKAO_LOGIN_BASE_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
-
-export const DEPLOYMENT_URL = 'https://dev.dadok.app';

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -4,3 +4,5 @@ export const DATA_URL = {
 };
 
 export const KAKAO_LOGIN_BASE_URL = `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorize/kakao?redirect_uri=${process.env.NEXT_PUBLIC_CLIENT_REDIRECT_URI}`;
+
+export const DEPLOYMENT_URL = 'https://dev.dadok.app';


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
### metadata에 프로덕션 URL만 노출되도록 수정
1. **환경변수에 `NEXT_DEPLOYMENT_URL`를 선언했어요**
``` env
NEXT_PUBLIC_PRODUCTION_URL=https://dev.dadok.app
```

2. `layout.tsx`, `sitemap.ts`, `robots.ts`, `schema.ts`코드에 있는
메타데이터와 관련된 `NEXT_HOST`를 제거하고, `NEXT_DEPLOYMENT_URL`로 대체했어요

# pr 포인트
### **환경변수에 `NEXT_DEPLOYMENT_URL`를 추가해주세요!!!**
``` env
NEXT_PUBLIC_PRODUCTION_URL=https://dev.dadok.app
```

# 관련 이슈

- Close #677 
