### PR TITLE
[#681] [fix] 프로필을 작성하지 않은 사용자가 모임 생성하지 못하도록 수정

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,7 +22,12 @@ const REDIRECT_SEARCH_KEY = SEARCH_PARAMS_KEYS.REDIRECT_PATHNAME;
 const EXCLUDE_AUTH_HEADER_API = ['/api/auth/token'];
 
 // 추가 프로필 등록이 반드시 필요한 path
-const NEED_PROFILE_PATHS = ['/bookarchive', '/profile/me', '/profile/me/edit'];
+const NEED_PROFILE_PATHS = [
+  '/bookarchive',
+  '/profile/me',
+  '/profile/me/edit',
+  '/group/create',
+];
 
 export const config = {
   matcher: [


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- 추가 프로필을 등록하지 않은 사용자가 모임 생성 페이지에 접근할 수 없도록 middleware에  `/group/create` path를 추가했어요.
<!-- - ex) 결제 기능 구현 -->

# 관련 이슈

- Close #681 <!--이슈번호-->
