### PR TITLE
[#685] [fix] iOS PWA 환경에서의 status bar 스타일 추가

### DIFF
--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -62,15 +62,14 @@ const BookSearchPage = () => {
 
   return (
     <>
-      <div
+      <TopHeader
+        text={'Discover'}
         className={`transition duration-500 ${
           watchedKeyword
             ? '-translate-y-[5.8rem] opacity-0'
             : 'translate-y-0 opacity-100'
         }`}
-      >
-        <TopHeader text={'Discover'} />
-      </div>
+      />
       <article
         className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
           watchedKeyword ? '-translate-y-[5.8rem]' : 'translate-y-0'

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -57,24 +57,29 @@ const BookSearchPage = () => {
     }
   }, [debouncedKeyword, getQueryParam, setQueryParams, removeQueryParam]);
 
-  /* TopHeader가 사라졌을 때 input의 위치 top: 6.15rem */
+  /* TopHeader가 사라졌을 때 input의 위치 top: topSafeArea + 6.15rem */
   const inputPositionClasses =
     watchedKeyword && 'sticky top-[calc(env(safe-area-inset-top)+6.15rem)]';
 
+  /* 검색어가 입력되었을 때 각 컨테이너의 애니메이션 class */
+  const discoverPageAnimationClasses = `transition duration-500 ${
+    watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
+  }`;
+  const headingOpacityClasses = `${
+    watchedKeyword ? 'opacity-0' : 'opacity-100'
+  }`;
+
   return (
     <>
-      <TopHeader
-        text={'Discover'}
-        className={`transition duration-500 ${
-          watchedKeyword
-            ? '-translate-y-[6.15rem] opacity-0'
-            : 'translate-y-0 opacity-100'
-        }`}
-      />
+      <TopHeader className={discoverPageAnimationClasses}>
+        <h1
+          className={`text-main-900 font-heading-bold ${headingOpacityClasses}`}
+        >
+          Discover
+        </h1>
+      </TopHeader>
       <article
-        className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
-          watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
-        }`}
+        className={`flex w-full flex-col gap-[3rem] ${discoverPageAnimationClasses}`}
       >
         <Input
           type="search"

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -14,6 +14,7 @@ import bookAPI from '@/apis/book';
 import SSRSafeSuspense from '@/components/common/SSRSafeSuspense';
 import useDebounceValue from '@/hooks/useDebounce';
 import useQueryParams from '@/hooks/useQueryParams';
+import useIsScrollAtTop from '@/hooks/useIsScrollAtTop';
 import { checkAuthentication } from '@/utils/helpers';
 
 import Loading from '@/components/common/Loading';
@@ -46,6 +47,8 @@ const BookSearchPage = () => {
   const watchedKeyword = watch('searchValue');
   const debouncedKeyword = useDebounceValue(watchedKeyword, 1000);
 
+  const { isScrollAtTop } = useIsScrollAtTop();
+
   /* debounce된 keyword값에 따라 queryParameter를 수정하는 useEffect */
   useEffect(() => {
     const queryValue = getQueryParam(KEYWORD);
@@ -71,7 +74,7 @@ const BookSearchPage = () => {
 
   return (
     <>
-      <TopHeader className={discoverPageAnimationClasses}>
+      <TopHeader blur={!isScrollAtTop} className={discoverPageAnimationClasses}>
         <h1
           className={`text-main-900 font-heading-bold ${headingOpacityClasses}`}
         >

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -58,7 +58,8 @@ const BookSearchPage = () => {
   }, [debouncedKeyword, getQueryParam, setQueryParams, removeQueryParam]);
 
   /* TopHeader가 사라졌을 때 input의 위치 top: 6.15rem */
-  const inputPositionClasses = watchedKeyword && 'sticky top-[6.15rem]';
+  const inputPositionClasses =
+    watchedKeyword && 'sticky top-[calc(env(safe-area-inset-bottom)+6.15rem)]';
 
   return (
     <>
@@ -66,13 +67,15 @@ const BookSearchPage = () => {
         text={'Discover'}
         className={`transition duration-500 ${
           watchedKeyword
-            ? '-translate-y-[6.15rem] opacity-0'
+            ? '-translate-y-[calc(env(safe-area-inset-bottom)+6.15rem)] opacity-0'
             : 'translate-y-0 opacity-100'
         }`}
       />
       <article
         className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
-          watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
+          watchedKeyword
+            ? '-translate-y-[calc(env(safe-area-inset-bottom)+6.15rem)]'
+            : 'translate-y-0'
         }`}
       >
         <Input

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -59,7 +59,7 @@ const BookSearchPage = () => {
 
   /* TopHeader가 사라졌을 때 input의 위치 top: 6.15rem */
   const inputPositionClasses =
-    watchedKeyword && 'sticky top-[calc(env(safe-area-inset-bottom)+6.15rem)]';
+    watchedKeyword && 'sticky top-[calc(env(safe-area-inset-top)+6.15rem)]';
 
   return (
     <>
@@ -67,14 +67,14 @@ const BookSearchPage = () => {
         text={'Discover'}
         className={`transition duration-500 ${
           watchedKeyword
-            ? '-translate-y-[calc(env(safe-area-inset-bottom)+6.15rem)] opacity-0'
+            ? '-translate-y-[calc(env(safe-area-inset-top)+6.15rem)] opacity-0'
             : 'translate-y-0 opacity-100'
         }`}
       />
       <article
         className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
           watchedKeyword
-            ? '-translate-y-[calc(env(safe-area-inset-bottom)+6.15rem)]'
+            ? '-translate-y-[calc(env(safe-area-inset-top)+6.15rem)]'
             : 'translate-y-0'
         }`}
       >

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -57,8 +57,8 @@ const BookSearchPage = () => {
     }
   }, [debouncedKeyword, getQueryParam, setQueryParams, removeQueryParam]);
 
-  /* TopHeader가 사라졌을 때 input의 위치 top: 5.8rem */
-  const inputPositionClasses = watchedKeyword && 'sticky top-[5.8rem]';
+  /* TopHeader가 사라졌을 때 input의 위치 top: 6.15rem */
+  const inputPositionClasses = watchedKeyword && 'sticky top-[6.15rem]';
 
   return (
     <>
@@ -66,13 +66,13 @@ const BookSearchPage = () => {
         text={'Discover'}
         className={`transition duration-500 ${
           watchedKeyword
-            ? '-translate-y-[5.8rem] opacity-0'
+            ? '-translate-y-[6.15rem] opacity-0'
             : 'translate-y-0 opacity-100'
         }`}
       />
       <article
         className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
-          watchedKeyword ? '-translate-y-[5.8rem]' : 'translate-y-0'
+          watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
         }`}
       >
         <Input

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -67,15 +67,13 @@ const BookSearchPage = () => {
         text={'Discover'}
         className={`transition duration-500 ${
           watchedKeyword
-            ? '-translate-y-[calc(env(safe-area-inset-top)+6.15rem)] opacity-0'
+            ? '-translate-y-[6.15rem] opacity-0'
             : 'translate-y-0 opacity-100'
         }`}
       />
       <article
         className={`flex w-full flex-col gap-[3rem] transition duration-500 ${
-          watchedKeyword
-            ? '-translate-y-[calc(env(safe-area-inset-top)+6.15rem)]'
-            : 'translate-y-0'
+          watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
         }`}
       >
         <Input

--- a/src/app/book/search/page.tsx
+++ b/src/app/book/search/page.tsx
@@ -63,7 +63,7 @@ const BookSearchPage = () => {
 
   /* 검색어가 입력되었을 때 각 컨테이너의 애니메이션 class */
   const discoverPageAnimationClasses = `transition duration-500 ${
-    watchedKeyword ? '-translate-y-[6.15rem]' : 'translate-y-0'
+    watchedKeyword ? '-translate-y-[6.05rem]' : 'translate-y-0'
   }`;
   const headingOpacityClasses = `${
     watchedKeyword ? 'opacity-0' : 'opacity-100'

--- a/src/app/bookarchive/page.tsx
+++ b/src/app/bookarchive/page.tsx
@@ -16,7 +16,9 @@ export default function BookArchivePage() {
 
   return (
     <div className="flex w-full flex-col gap-[1rem] pb-[2rem]">
-      <TopHeader text="BookArchive" blur={!isScrollAtTop} />
+      <TopHeader blur={!isScrollAtTop}>
+        <h1 className="text-main-900 font-heading-bold">BookArchive</h1>
+      </TopHeader>
       {/* TODO: 스켈레톤 컴포넌트로 교체 */}
       <SSRSafeSuspense fallback={null}>
         <Contents />

--- a/src/app/bookarchive/page.tsx
+++ b/src/app/bookarchive/page.tsx
@@ -9,10 +9,14 @@ import BookArchiveForAuth from '@/components/bookArchive/BookArchiveForAuth';
 import BookArchiveForUnAuth from '@/components/bookArchive/BookArchiveForUnAuth';
 import TopHeader from '@/components/common/TopHeader';
 
+import useIsScrollAtTop from '@/hooks/useIsScrollAtTop';
+
 export default function BookArchivePage() {
+  const { isScrollAtTop } = useIsScrollAtTop();
+
   return (
     <div className="flex w-full flex-col gap-[1rem] pb-[2rem]">
-      <TopHeader text="BookArchive" />
+      <TopHeader text="BookArchive" blur={!isScrollAtTop} />
       {/* TODO: 스켈레톤 컴포넌트로 교체 */}
       <SSRSafeSuspense fallback={null}>
         <Contents />

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -12,6 +12,7 @@ import { useMyProfileId } from '@/queries/user/useMyProfileQuery';
 import useMounted from '@/hooks/useMounted';
 import { checkAuthentication } from '@/utils/helpers';
 import useToast from '@/components/common/Toast/useToast';
+import useIsScrollAtTop from '@/hooks/useIsScrollAtTop';
 
 import FloatingButton from '@/components/common/FloatingButton';
 import Loading from '@/components/common/Loading';
@@ -28,6 +29,7 @@ import CreateGroupBanner from '@/components/bookGroup/banner/CreateGroupBanner';
 const GroupPage = () => {
   const router = useRouter();
   const { show: showToast } = useToast();
+  const { isScrollAtTop } = useIsScrollAtTop();
 
   const isAuthenticated = checkAuthentication();
 
@@ -50,7 +52,7 @@ const GroupPage = () => {
 
   return (
     <>
-      <TopHeader text="Group" />
+      <TopHeader text="Group" blur={!isScrollAtTop} />
       <div className="flex w-full flex-col gap-[2rem]">
         <SearchGroupInput onClick={handleSearchInputClick} />
         <SSRSafeSuspense fallback={<PageSkeleton />}>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -52,7 +52,9 @@ const GroupPage = () => {
 
   return (
     <>
-      <TopHeader text="Group" blur={!isScrollAtTop} />
+      <TopHeader blur={!isScrollAtTop}>
+        <h1 className="text-main-900 font-heading-bold">Group</h1>
+      </TopHeader>
       <div className="flex w-full flex-col gap-[2rem]">
         <SearchGroupInput onClick={handleSearchInputClick} />
         <SSRSafeSuspense fallback={<PageSkeleton />}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,9 @@ export const metadata: Metadata = {
     { rel: 'icon', url: '/favicon.ico' },
   ],
   appleWebApp: {
+    capable: true,
     title: '다독다독',
+    statusBarStyle: 'default',
     startupImage: appleSplashScreens,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,7 @@ export const metadata: Metadata = {
   ],
   appleWebApp: {
     title: '다독다독',
+    statusBarStyle: 'black-translucent',
     startupImage: appleSplashScreens,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,6 @@ export const metadata: Metadata = {
     default: '다독다독',
   },
   description: '책에 대한 인사이트를 공유하고 소통하는 독서 소셜 플랫폼',
-  themeColor: '#FFFFFF',
   viewport:
     'minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, viewport-fit=cover',
   verification: {
@@ -34,9 +33,7 @@ export const metadata: Metadata = {
     { rel: 'icon', url: '/favicon.ico' },
   ],
   appleWebApp: {
-    capable: true,
     title: '다독다독',
-    statusBarStyle: 'default',
     startupImage: appleSplashScreens,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
     default: '다독다독',
   },
   description: '책에 대한 인사이트를 공유하고 소통하는 독서 소셜 플랫폼',
+  themeColor: '#FFFFFF',
   viewport:
     'minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, viewport-fit=cover',
   verification: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     title: '다독다독',
-    statusBarStyle: 'default',
+    statusBarStyle: 'black-translucent',
     startupImage: appleSplashScreens,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,8 +34,9 @@ export const metadata: Metadata = {
     { rel: 'icon', url: '/favicon.ico' },
   ],
   appleWebApp: {
+    capable: true,
     title: '다독다독',
-    statusBarStyle: 'black-translucent',
+    statusBarStyle: 'default',
     startupImage: appleSplashScreens,
   },
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,7 +27,7 @@ const LoginPage = () => {
         </p>
       </article>
 
-      <section className="absolute inset-x-[2rem] bottom-[calc(env(safe-area-inset-bottom)+2rem)] mx-auto flex max-w-[41rem] flex-col justify-center gap-[1rem]">
+      <section className="absolute inset-x-[2rem] bottom-[2rem] mx-auto flex max-w-[41rem] flex-col justify-center gap-[1rem]">
         <LoginLink>
           <Button size="full" colorScheme="kakao">
             <div className="flex w-full items-center justify-center">

--- a/src/app/manifest.webmanifest
+++ b/src/app/manifest.webmanifest
@@ -2,6 +2,8 @@
   "name": "다독다독",
   "short_name": "다독다독",
   "description": "책에 대한 인사이트를 공유하고 소통하는 독서 소셜 플랫폼",
+  "theme_color": "#FFA436",
+  "background_color": "#FFFFFF",
   "display": "standalone",
   "scope": "./",
   "start_url": "./",

--- a/src/app/manifest.webmanifest
+++ b/src/app/manifest.webmanifest
@@ -2,8 +2,6 @@
   "name": "다독다독",
   "short_name": "다독다독",
   "description": "책에 대한 인사이트를 공유하고 소통하는 독서 소셜 플랫폼",
-  "theme_color": "#FFA436",
-  "background_color": "#FFFFFF",
   "display": "standalone",
   "scope": "./",
   "start_url": "./",

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -45,7 +45,9 @@ const MyProfileForUnAuth = () => {
 
   return (
     <>
-      <TopHeader text="Profile" blur={!isScrollAtTop} />
+      <TopHeader blur={!isScrollAtTop}>
+        <h1 className="text-main-900 font-heading-bold">Profile</h1>
+      </TopHeader>
       <div className="flex flex-col gap-[3rem]">
         <div className="mb-[2rem] flex items-center gap-[1rem]">
           <Avatar size="large" />
@@ -101,7 +103,11 @@ const MyProfileForAuth = () => {
 
   return (
     <>
-      <TopHeader text="Profile" blur={!isScrollAtTop}>
+      <TopHeader
+        className="flex items-center justify-between"
+        blur={!isScrollAtTop}
+      >
+        <h1 className="text-main-900 font-heading-bold">Profile</h1>
         <Menu>
           <Menu.Toggle />
           <Menu.DropdownList>

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -10,6 +10,8 @@ import userKeys from '@/queries/user/key';
 import { deleteAuthSession } from '@/server/session';
 import { deleteCookie } from '@/utils/cookie';
 import { checkAuthentication } from '@/utils/helpers';
+import useIsScrollAtTop from '@/hooks/useIsScrollAtTop';
+
 import { SESSION_COOKIES_KEYS } from '@/constants';
 import { IconArrowRight } from '@public/icons';
 
@@ -30,6 +32,7 @@ const USER_ID = 'me';
 
 const MyProfilePage = () => {
   const isAuthenticated = checkAuthentication();
+
   return (
     <SSRSafeSuspense fallback={<Loading fullpage />}>
       {isAuthenticated ? <MyProfileForAuth /> : <MyProfileForUnAuth />}
@@ -38,9 +41,11 @@ const MyProfilePage = () => {
 };
 
 const MyProfileForUnAuth = () => {
+  const { isScrollAtTop } = useIsScrollAtTop();
+
   return (
     <>
-      <TopHeader text="Profile" />
+      <TopHeader text="Profile" blur={!isScrollAtTop} />
       <div className="flex flex-col gap-[3rem]">
         <div className="mb-[2rem] flex items-center gap-[1rem]">
           <Avatar size="large" />
@@ -81,6 +86,7 @@ const MyProfileForUnAuth = () => {
 const MyProfileForAuth = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const { isScrollAtTop } = useIsScrollAtTop();
 
   const handleLogoutButtonClick = async () => {
     try {
@@ -95,7 +101,7 @@ const MyProfileForAuth = () => {
 
   return (
     <>
-      <TopHeader text="Profile">
+      <TopHeader text="Profile" blur={!isScrollAtTop}>
         <Menu>
           <Menu.Toggle />
           <Menu.DropdownList>

--- a/src/components/common/TopHeader.tsx
+++ b/src/components/common/TopHeader.tsx
@@ -1,19 +1,17 @@
 import { PropsWithChildren } from 'react';
 
 type TopHeaderProps = PropsWithChildren<{
-  text: string;
   blur?: boolean;
   className?: string;
 }>;
 
 const DEFAULT_HEADER_CLASSES =
-  'fixed left-0 right-0 top-0 z-30 mx-auto flex w-full max-w-[43rem] items-center justify-between border-0 px-[2rem] pb-[1rem] pt-[calc(env(safe-area-inset-top)+2rem)] transition duration-1000';
+  'fixed left-0 right-0 top-0 z-30 mx-auto w-full max-w-[43rem] border-0 px-[2rem] pb-[1rem] pt-[calc(env(safe-area-inset-top)+2rem)] transition duration-1000';
 
 const BLUR_HEADER_CLASSES =
   'border-b-black-100 border-b-[0.01rem] bg-[#FFFFFFBF] backdrop-blur-[1.6rem]';
 
 const TopHeader = ({
-  text,
   blur = false,
   className = '',
   children,
@@ -22,7 +20,6 @@ const TopHeader = ({
 
   return (
     <header className={`${DEFAULT_HEADER_CLASSES} ${blurClasses} ${className}`}>
-      <h1 className="text-main-900 font-heading-bold">{text}</h1>
       {children}
     </header>
   );

--- a/src/components/common/TopHeader.tsx
+++ b/src/components/common/TopHeader.tsx
@@ -2,11 +2,14 @@ import { PropsWithChildren } from 'react';
 
 type TopHeaderProps = PropsWithChildren<{
   text: string;
+  className?: string;
 }>;
 
-const TopHeader = ({ text, children }: TopHeaderProps) => {
+const TopHeader = ({ text, className, children }: TopHeaderProps) => {
   return (
-    <header className="flex w-full items-center justify-between pb-[2rem]">
+    <header
+      className={`fixed left-0 right-0 top-0 z-50 mx-auto flex w-full max-w-[43rem] items-center justify-between bg-white px-[2rem] pt-[2rem] ${className}`}
+    >
       <h1 className="text-main-900 font-heading-bold">{text}</h1>
       {children}
     </header>

--- a/src/components/common/TopHeader.tsx
+++ b/src/components/common/TopHeader.tsx
@@ -2,14 +2,26 @@ import { PropsWithChildren } from 'react';
 
 type TopHeaderProps = PropsWithChildren<{
   text: string;
+  blur?: boolean;
   className?: string;
 }>;
 
-const TopHeader = ({ text, className, children }: TopHeaderProps) => {
+const DEFAULT_HEADER_CLASSES =
+  'fixed left-0 right-0 top-0 z-30 mx-auto flex w-full max-w-[43rem] items-center justify-between border-0 px-[2rem] pb-[1rem] pt-[calc(env(safe-area-inset-top)+2rem)] transition duration-1000';
+
+const BLUR_HEADER_CLASSES =
+  'border-b-black-100 border-b-[0.01rem] bg-[#FFFFFFBF] backdrop-blur-[1.6rem]';
+
+const TopHeader = ({
+  text,
+  blur = false,
+  className = '',
+  children,
+}: TopHeaderProps) => {
+  const blurClasses = blur ? BLUR_HEADER_CLASSES : 'bg-white';
+
   return (
-    <header
-      className={`fixed left-0 right-0 top-0 z-50 mx-auto flex w-full max-w-[43rem] items-center justify-between bg-white px-[2rem] pt-[calc(env(safe-area-inset-top)+2rem)] ${className}`}
-    >
+    <header className={`${DEFAULT_HEADER_CLASSES} ${blurClasses} ${className}`}>
       <h1 className="text-main-900 font-heading-bold">{text}</h1>
       {children}
     </header>

--- a/src/components/common/TopHeader.tsx
+++ b/src/components/common/TopHeader.tsx
@@ -8,7 +8,7 @@ type TopHeaderProps = PropsWithChildren<{
 const TopHeader = ({ text, className, children }: TopHeaderProps) => {
   return (
     <header
-      className={`fixed left-0 right-0 top-0 z-50 mx-auto flex w-full max-w-[43rem] items-center justify-between bg-white px-[2rem] pt-[2rem] ${className}`}
+      className={`fixed left-0 right-0 top-0 z-50 mx-auto flex w-full max-w-[43rem] items-center justify-between bg-white px-[2rem] pt-[calc(env(safe-area-inset-top)+2rem)] ${className}`}
     >
       <h1 className="text-main-900 font-heading-bold">{text}</h1>
       {children}

--- a/src/components/common/TopNavigation.tsx
+++ b/src/components/common/TopNavigation.tsx
@@ -8,17 +8,17 @@ type ItemProps = TopNavigationProps;
 
 const TopNavigation = ({ children }: TopNavigationProps) => {
   return (
-    <div className="fixed left-0 right-0 top-0 z-50 mx-auto flex h-[2.4rem] w-full max-w-[43rem] items-center justify-center bg-white px-[4rem] py-[2.7rem] font-body1-regular">
+    <header className="fixed left-0 right-0 top-0 z-50 mx-auto flex h-[2.4rem] w-full max-w-[43rem] items-center justify-center bg-white px-[4rem] pb-[2.7rem] pt-[calc(env(safe-area-inset-top)+2.7rem)] font-body1-regular">
       {children}
-    </div>
+    </header>
   );
 };
 
 const LeftItem = ({ children }: ItemProps) => {
   return (
-    <div className="absolute left-[0rem] flex pl-[2rem] [&_svg]:h-[2rem] [&_svg]:w-[2rem] [&_svg]:cursor-pointer">
+    <nav className="absolute left-[0rem] flex pl-[2rem] [&_svg]:h-[2rem] [&_svg]:w-[2rem] [&_svg]:cursor-pointer">
       {children}
-    </div>
+    </nav>
   );
 };
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,7 +15,7 @@ const Layout = ({ children }: LayoutProps) => {
   const isRootPath = pathname && rootPaths.includes(pathname);
 
   const dynamicClass = isRootPath
-    ? 'pb-[calc(env(safe-area-inset-bottom)+7rem)] pt-[calc(env(safe-area-inset-top)+2rem)]'
+    ? 'pb-[calc(env(safe-area-inset-bottom)+7rem)] pt-[calc(env(safe-area-inset-top)+7.15rem)]'
     : 'pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-[calc(env(safe-area-inset-top)+5.4rem)]';
 
   return (

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,8 +15,8 @@ const Layout = ({ children }: LayoutProps) => {
   const isRootPath = pathname && rootPaths.includes(pathname);
 
   const dynamicClass = isRootPath
-    ? 'pb-[calc(env(safe-area-inset-bottom)+7rem)] pt-[2rem]'
-    : 'pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-[5.4rem]';
+    ? 'pb-[calc(env(safe-area-inset-bottom)+7rem)] pt-[calc(env(safe-area-inset-top)+2rem)]'
+    : 'pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-[calc(env(safe-area-inset-top)+5.4rem)]';
 
   return (
     <>

--- a/src/hooks/useIsScrollAtTop.ts
+++ b/src/hooks/useIsScrollAtTop.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+const useIsScrollAtTop = () => {
+  const [isScrollAtTop, setIsScrollAtTop] = useState(true);
+
+  const listener = () => {
+    setIsScrollAtTop(window.scrollY === 0);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', listener);
+    return () => {
+      window.removeEventListener('scroll', listener);
+    };
+  }, []);
+
+  return { isScrollAtTop };
+};
+
+export default useIsScrollAtTop;

--- a/src/stories/common/TopHeader.stories.tsx
+++ b/src/stories/common/TopHeader.stories.tsx
@@ -1,11 +1,14 @@
 import { Meta, StoryObj } from '@storybook/react';
+
 import { IconHamburger } from '@public/icons';
 import TopHeader from '@/components/common/TopHeader';
+
+import { appLayoutMeta } from '@/stories/meta';
 
 const meta: Meta<typeof TopHeader> = {
   title: 'Common/TopHeader',
   component: TopHeader,
-  tags: ['autodocs'],
+  ...appLayoutMeta,
 };
 
 export default meta;

--- a/src/stories/common/TopHeader.stories.tsx
+++ b/src/stories/common/TopHeader.stories.tsx
@@ -13,21 +13,29 @@ export default meta;
 type Story = StoryObj<typeof TopHeader>;
 
 export const Default: Story = {
-  args: { text: 'BookArchive' },
-  render: args => <TopHeader {...args} />,
+  render: () => (
+    <TopHeader>
+      <h1 className="text-main-900 font-heading-bold">BookArchive</h1>
+    </TopHeader>
+  ),
 };
 
-export const WithMenu: Story = {
-  args: { text: 'Profile' },
+export const WithChildren: Story = {
+  args: {
+    className: 'flex items-center justify-between',
+  },
   render: args => (
-    <TopHeader {...args}>
-      <button
-        onClick={() => {
-          alert('HAMBURGUR MENU!🍔');
-        }}
-      >
-        <IconHamburger width={20} height={20} alt="햄버거메뉴" />
-      </button>
-    </TopHeader>
+    <main className="w-full max-w-[43rem] bg-black-300">
+      <TopHeader {...args}>
+        <h1 className="text-main-900 font-heading-bold">Profile</h1>
+        <button
+          onClick={() => {
+            alert('HAMBURGUR MENU!🍔');
+          }}
+        >
+          <IconHamburger width={20} height={20} alt="햄버거메뉴" />
+        </button>
+      </TopHeader>
+    </main>
   ),
 };


### PR DESCRIPTION
<!-- 제목은`[#이슈번호] 이슈 제목` 으로 작성한다. -->
<!-- - ex) [#8] 결제 기능 -->

# 구현 내용
- PWA환경에서 더 이상 StatusBar가 고정 색깔로 표현되지 않아요
  - 대신 body 태그가 StatusBar의 영역을 차지합니다.
  - top-safe-area 적용으로 컨탠츠가 해당 영역을 침범하지 않도록 했습니다.
- TopHeader를 리팩터링 했어요
  - position속성이 fixed로 바뀌었습니다.
  - 더 이상 text props에 의존적이지 않습니다. (text props를 제거되고 className props가 추가 되었어요.)
- useIsScrollAtTop 커스텀 훅을 작성했어요
  - isScrollAtTop 변수를 통해 스크롤이 아래로 이동하면 TopHeader의 배경이 blur 처리됩니다.

# 스크린샷
<img src="https://github.com/user-attachments/assets/2ef30ee3-8365-4722-8090-dc6e02a6e7f6" width=215/>
<img src="https://github.com/user-attachments/assets/1681586a-f67e-4a14-ac4d-f401879c94bf" width=215 />
<img src="https://github.com/user-attachments/assets/8c58b237-74b3-4ba0-917e-32122d728667" width=215 />

<!-- 없는 경우 생략한다. -->

# pr 포인트
- 리팩터링된 TopHeader 코드
- 새로운 TopHeader가 적용된 `북카이브`, `도서 검색`, `독서 모임`, `내 프로필` 코드

# 관련 이슈

- Close #685 
